### PR TITLE
Performance Optimisation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.exposed.json)
     implementation(libs.logback.classic)
     implementation(libs.postgresql)
+    implementation(libs.hikaricp)
     implementation(libs.flyway.core)
     implementation(libs.flyway.database.postgresql)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ testcontainers-bom = "2.0.5"
 mockk = "1.14.9"
 kotest-extensions-testcontainers = "2.0.2"
 detekt-rules = "1.1.0"
+hikari = "5.1.0"
 
 [libraries]
 ktor-server-core = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
@@ -50,6 +51,7 @@ exposed-json = { module = "org.jetbrains.exposed:exposed-json", version.ref = "e
 
 logback-classic = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgres" }
+hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 
 flyway-core = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flyway-database-postgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }

--- a/specs/concurrency-optimisations.md
+++ b/specs/concurrency-optimisations.md
@@ -14,6 +14,7 @@ This spec addresses the backend issues. It does **not** change the public API, t
 - Make `POST /versions` write atomically in **one** transaction for version + tags (today it opens three independent transactions).
 - Replace the racy check-then-act in `createOrUpdate` with a Postgres UPSERT (`INSERT … ON CONFLICT DO UPDATE`) against the existing `UNIQUE (candidate, version, distribution, platform)` index.
 - Keep audit-log writes as best-effort and out of the main transaction (today's behaviour, intentionally preserved).
+- Configure Exposed with an explicit `defaultIsolationLevel` so coroutine context setup never probes the database — otherwise an unavailable Postgres deadlocks the request coroutine instead of returning a clean error.
 
 ## Context: HTTP/2 Stream Limit (Non-Goal)
 
@@ -36,6 +37,7 @@ The `too many concurrent streams` error is raised by the **client's** HTTP/2 sta
 - **R6.** Audit logging remains best-effort, in its own transaction. An audit insert failure must not roll back the version write and must surface only as a `WARN` log (preserves current behaviour).
 - **R7.** The JDBC URL no longer enables verbose pgjdbc logging (`loglevel=2` removed).
 - **R8.** `./gradlew check` passes. Existing acceptance, integration, and unit tests continue to pass without modifying their assertions. New tests cover the concurrency race and the pool wiring.
+- **R9.** Exposed is configured with an explicit `defaultIsolationLevel`. When the database is unavailable, `/meta/health` (and any other transactional request path) must fail fast with the expected error response rather than deadlock the request coroutine.
 
 ## Rules
 
@@ -128,6 +130,7 @@ implementation(libs.hikaricp)
 - **Returning the version id.** Use the upsert's `RETURNING id` rather than issuing a follow-up `SELECT id`. The post-upsert flow needs the id for tag replacement.
 - **Flyway shares the pool.** Flyway runs once at startup and must be configured with the **same** `HikariDataSource` (`Flyway.configure().dataSource(ds)`), not a separate `DriverManager` URL.
 - **Health repository uses the pool.** `PostgresHealthRepository` must execute against the pool (otherwise the health check is unrepresentative of the data path). The single `Database.connect(dataSource)` wiring in `configureDatabase` should cover this transparently — verify when implementing.
+- **Explicit isolation level avoids a coroutine deadlock when the pool can't serve a connection.** Without `DatabaseConfig { defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED }`, Exposed lazily probes the database via `db.metadata { defaultTransactionIsolation }` inside `TransactionCoroutineElement.updateThreadContext`. If the pool throws `SQLTransientConnectionException` there (e.g. Postgres unreachable), kotlinx-coroutines wraps it as `CoroutinesInternalError` — a "fatal exception in coroutines machinery" — and the suspended continuation is never resumed, so the request hangs indefinitely. Setting the level explicitly on `Database.connect` moves any connection-acquisition failure into the transaction body where `Either.catch {}` handles it cleanly and the health check returns `503` as designed.
 - **No schema migrations.** The UPSERT relies on the existing unique constraints from `V2` (versions) and `V12` (version_tags). No new Flyway migration files.
 - **No public API or OpenAPI changes.** Request/response contracts for all endpoints are untouched; `src/main/resources/openapi/documentation.yaml` does **not** need updating.
 - **Detekt / ktlint.** New configuration helpers must follow existing patterns in `ConfigExtensions.kt` (Arrow `Option`, no nullables, expression bodies where natural). No suppressions.
@@ -156,7 +159,7 @@ implementation(libs.hikaricp)
 Independently committable, in dependency order. Each slice is a single Conventional Commit.
 
 1. **`chore: drop verbose pgjdbc loglevel from JDBC URL`** — one-line change in `ConfigExtensions.kt`. No test changes. Smallest, safest slice; lands first so subsequent slice verification isn't polluted with driver-level noise.
-2. **`feat: introduce HikariCP connection pool`** — add Hikari dependency in `libs.versions.toml` and `build.gradle.kts`; add `database.pool.*` to `application.conf`; extend `AppConfig`/`DefaultAppConfig`; change `configureDatabase` to build a `HikariDataSource` and pass it to both `Database.connect(dataSource)` and `Flyway.configure().dataSource(ds)`. New unit test for `AppConfig` parsing; new integration test for pool starvation behaviour.
+2. **`feat: introduce HikariCP connection pool`** — add Hikari dependency in `libs.versions.toml` and `build.gradle.kts`; add `database.pool.*` to `application.conf`; extend `AppConfig`/`DefaultAppConfig`; change `configureDatabase` to build a `HikariDataSource` and pass it to both `Database.connect(dataSource, databaseConfig = DatabaseConfig { defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED })` and `Flyway.configure().dataSource(ds)`. The explicit isolation level is mandatory (see R9) — without it, an unavailable database deadlocks the request coroutine instead of returning a clean error. New unit test for `AppConfig` parsing; new integration test for pool starvation behaviour.
 3. **`refactor: upsert versions to remove create-or-update race`** — replace check-then-act in `PostgresVersionRepository.createOrUpdate` with Exposed `upsert {}` targeting `(candidate, version, distribution, platform)`. New acceptance test for concurrent same-version POSTs (R4). Existing `IdempotentPostVersionAcceptanceSpec` continues to pass.
 4. **`refactor: write version and tags in a single transaction`** — wrap the version+tags work in `VersionServiceImpl.createOrUpdate` in one outer `newSuspendedTransaction`. Keep `logAudit` outside it. New focused test for audit-failure isolation (R6) and single-transaction boundary (R5).
 
@@ -167,6 +170,7 @@ After all slices are merged:
 - [ ] `./gradlew check` passes cleanly (compile + detekt + ktlint + tests).
 - [ ] `grep -RIn "loglevel" src/main` returns no hits.
 - [ ] HikariCP is the only `DataSource` wired into Exposed and Flyway.
+- [ ] `HealthCheckAcceptanceSpec` "return FAILURE status when database is unavailable" completes within seconds (Hikari's `connectionTimeout`), not the 60s `runTest` ceiling — proves R9 holds.
 - [ ] New concurrent-POST acceptance test passes consistently across at least 10 local runs.
 - [ ] Manual smoke: boot against a local Postgres, send 50 concurrent `POST /versions` for the same version, observe all `204` responses and exactly one row in `versions`.
 - [ ] OpenAPI spec confirmed **unchanged** (no endpoint contract changes).

--- a/specs/concurrency-optimisations.md
+++ b/specs/concurrency-optimisations.md
@@ -1,0 +1,173 @@
+# Concurrency & Throughput Optimisations Specification
+
+## Overview
+
+A vendor consuming `POST /versions` reports client-side `IOException: too many concurrent streams` when driving requests from a virtual-thread HTTP/2 client. Investigation found:
+
+1. The application server (Ktor Netty) speaks HTTP/1.1 only — the HTTP/2 stream limit lives in the load balancer in front of it, not in our code.
+2. The backend, however, has several real concurrency issues that make every request slower than necessary, which keeps HTTP/2 streams open longer and causes the LB's per-connection stream cap to be hit far sooner than it should be.
+
+This spec addresses the backend issues. It does **not** change the public API, the database schema, the OpenAPI document, or the HTTP/2 settings of the load balancer.
+
+**Key Properties:**
+- Introduce HikariCP as a real JDBC connection pool (currently `DriverManager` opens a fresh TCP+auth connection per transaction).
+- Make `POST /versions` write atomically in **one** transaction for version + tags (today it opens three independent transactions).
+- Replace the racy check-then-act in `createOrUpdate` with a Postgres UPSERT (`INSERT … ON CONFLICT DO UPDATE`) against the existing `UNIQUE (candidate, version, distribution, platform)` index.
+- Keep audit-log writes as best-effort and out of the main transaction (today's behaviour, intentionally preserved).
+
+## Context: HTTP/2 Stream Limit (Non-Goal)
+
+The `too many concurrent streams` error is raised by the **client's** HTTP/2 stack when it exceeds the server's `SETTINGS_MAX_CONCURRENT_STREAMS`. In this deployment that setting is owned by the DigitalOcean Load Balancer (or whatever ingress terminates TLS), not by Ktor — `application.conf` declares only a plaintext connector on port 8080 and there is no SSL/ALPN configuration, so the app itself serves HTTP/1.1 only.
+
+**Out of scope for this spec:**
+- Changing or documenting the LB's `MAX_CONCURRENT_STREAMS`.
+- Enabling HTTP/2 on the Ktor server.
+- Client-side guidance for the reporter (handled separately).
+
+**In scope:** reducing per-request backend latency so that streams complete faster, which is the most leveraged way for us to reduce how often clients hit the LB's limit.
+
+## Requirements
+
+- **R1.** A pooled `javax.sql.DataSource` (HikariCP) is wired into Exposed and Flyway; no production code path uses `Database.connect(url, user, password, driver)`.
+- **R2.** Pool size, minimum idle, connection timeout, max lifetime, and idle timeout are configurable through `application.conf` and environment variables, with safe defaults for a single-pod deployment against default Postgres (`max_connections = 100`).
+- **R3.** A single `POST /versions` request performs **at most one** JDBC connection acquisition for the version write + tag replacement. Audit may use a separate short-lived transaction by design — see R6.
+- **R4.** The version write is idempotent under concurrency: two concurrent `POST /versions` requests with the same `(candidate, version, distribution, platform)` both return `204 No Content` and result in exactly one row, with no unique-constraint exception surfacing to the client.
+- **R5.** Tag replacement is atomic with the version write — if tag replacement fails, the version write rolls back (today they are in separate transactions).
+- **R6.** Audit logging remains best-effort, in its own transaction. An audit insert failure must not roll back the version write and must surface only as a `WARN` log (preserves current behaviour).
+- **R7.** The JDBC URL no longer enables verbose pgjdbc logging (`loglevel=2` removed).
+- **R8.** `./gradlew check` passes. Existing acceptance, integration, and unit tests continue to pass without modifying their assertions. New tests cover the concurrency race and the pool wiring.
+
+## Rules
+
+**Before implementing, you MUST read and internalize:**
+- `.claude/rules/kotlin.md` — Arrow `Either`/`Option`, no nullables, smart constructors.
+- `.claude/rules/hexagonal-architecture.md` — infrastructure stays in the secondary adapter layer; ports/domain do not import `HikariCP`.
+- `.claude/rules/kotest.md` — ShouldSpec, three-layer test strategy, Testcontainers for DB tests.
+- `.claude/rules/quality-gates.md` — no `@Suppress`, no `@Disabled`, no relaxing detekt/ktlint.
+
+**If a slice prompt conflicts with the rules, THE RULES WIN.**
+
+## Configuration
+
+### New `database.pool` block in `application.conf`
+
+```hocon
+database {
+    host = "localhost"
+    host = ${?DATABASE_HOST}
+    port = 5432
+    port = ${?DATABASE_PORT}
+    username = "postgres"
+    username = ${?DATABASE_USERNAME}
+    password = "postgres"
+    password = ${?DATABASE_PASSWORD}
+
+    pool {
+        maxSize = 20
+        maxSize = ${?DATABASE_POOL_MAX_SIZE}
+        minIdle = 2
+        minIdle = ${?DATABASE_POOL_MIN_IDLE}
+        connectionTimeoutMs = 5000
+        connectionTimeoutMs = ${?DATABASE_POOL_CONNECTION_TIMEOUT_MS}
+        maxLifetimeMs = 1800000
+        maxLifetimeMs = ${?DATABASE_POOL_MAX_LIFETIME_MS}
+        idleTimeoutMs = 600000
+        idleTimeoutMs = ${?DATABASE_POOL_IDLE_TIMEOUT_MS}
+    }
+}
+```
+
+### `AppConfig` additions
+
+```kotlin
+interface AppConfig {
+    // existing fields …
+    val databasePoolMaxSize: Int
+    val databasePoolMinIdle: Int
+    val databasePoolConnectionTimeoutMs: Long
+    val databasePoolMaxLifetimeMs: Long
+    val databasePoolIdleTimeoutMs: Long
+}
+```
+
+Defaults tuned for **single-pod deployment against Postgres `max_connections = 100`**:
+- `maxSize = 20` → leaves ample headroom (Flyway, ad-hoc queries, future scale).
+- `minIdle = 2` → keeps a couple of connections warm to absorb idle-to-active spikes.
+- `connectionTimeoutMs = 5000` → fail fast if the pool is starved rather than holding HTTP streams open indefinitely.
+- `maxLifetimeMs = 30 min`, `idleTimeoutMs = 10 min` → standard HikariCP recommendations.
+
+### `jdbcUrl` change
+
+In `ConfigExtensions.kt`, drop the `loglevel=2` query parameter:
+
+```kotlin
+// before
+get() = "jdbc:postgresql://$databaseHost:$databasePort/$databaseName?sslMode=prefer&loglevel=2"
+// after
+get() = "jdbc:postgresql://$databaseHost:$databasePort/$databaseName?sslMode=prefer"
+```
+
+### Dependency added
+
+`gradle/libs.versions.toml`:
+```toml
+hikari = "5.1.0"   # latest stable at time of writing — bump as appropriate
+hikaricp = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
+```
+
+`build.gradle.kts`:
+```kotlin
+implementation(libs.hikaricp)
+```
+
+## Extra Considerations
+
+- **Transaction nesting in Exposed.** `dbQuery` uses `newSuspendedTransaction(Dispatchers.IO) { … }`. When invoked inside an enclosing `newSuspendedTransaction`, Exposed reuses the same connection — no new helper is needed. The slice that wraps version + tag work simply opens one outer `newSuspendedTransaction` in `VersionServiceImpl.createOrUpdate` and lets the nested repository calls participate.
+- **Audit remains separate by design.** Per R6, `auditRepo.recordAudit(...)` must execute **outside** the outer transaction so that an audit failure does not roll back the version write. The current best-effort warn-log behaviour is preserved verbatim.
+- **UPSERT target.** Exposed 0.57 ships an `upsert {}` builder that compiles to Postgres `INSERT … ON CONFLICT (…) DO UPDATE SET …`. Target the `(candidate, version, distribution, platform)` columns. Note: the underlying database column is still named `vendor` despite the Kotlin field being `distribution` — the Exposed `VersionsTable` already maps this correctly, so the upsert conflict target uses `VersionsTable.distribution`.
+- **Returning the version id.** Use the upsert's `RETURNING id` rather than issuing a follow-up `SELECT id`. The post-upsert flow needs the id for tag replacement.
+- **Flyway shares the pool.** Flyway runs once at startup and must be configured with the **same** `HikariDataSource` (`Flyway.configure().dataSource(ds)`), not a separate `DriverManager` URL.
+- **Health repository uses the pool.** `PostgresHealthRepository` must execute against the pool (otherwise the health check is unrepresentative of the data path). The single `Database.connect(dataSource)` wiring in `configureDatabase` should cover this transparently — verify when implementing.
+- **No schema migrations.** The UPSERT relies on the existing unique constraints from `V2` (versions) and `V12` (version_tags). No new Flyway migration files.
+- **No public API or OpenAPI changes.** Request/response contracts for all endpoints are untouched; `src/main/resources/openapi/documentation.yaml` does **not** need updating.
+- **Detekt / ktlint.** New configuration helpers must follow existing patterns in `ConfigExtensions.kt` (Arrow `Option`, no nullables, expression bodies where natural). No suppressions.
+
+## Testing Considerations
+
+**Framework:** Kotest `ShouldSpec`, MockK for unit tests, Testcontainers Postgres for integration/acceptance tests (already in place).
+
+**Acceptance (`@Tag("acceptance")`)** — golden-path coverage for the optimisations:
+- **Concurrent same-version POST.** Fire N (e.g. 20) coroutines simultaneously, each posting the same `(candidate, version, distribution, platform)` payload, all expected to return `204 No Content`; assert exactly one row exists in `versions` after. Exercises the UPSERT race fix (R4).
+- **Concurrent same-version POST with tags.** Same scenario but with `tags` payload; assert tag rows match the final write only (no orphaned tags from a partially applied attempt). Exercises R5.
+- **Existing `IdempotentPostVersionAcceptanceSpec` continues to pass unchanged.**
+
+**Integration (`@Tag("integration")`)**:
+- **Pool wiring.** Open more concurrent `dbQuery {}` calls than `maxSize`, with a small fixed `maxSize`, and assert all complete successfully (queued requests served as connections free up).
+- **Single-transaction write path.** A focused test on `VersionServiceImpl` with a spy/fake repository asserting that the version + tags work executes inside a single outer `newSuspendedTransaction` and audit executes in its own. Acceptable alternative: enable `log_statement = 'all'` on the test container and assert a single `BEGIN/COMMIT` pair for the version+tags work.
+
+**Unit**:
+- **`AppConfig` parsing.** Verify the new `database.pool.*` keys load from HOCON with defaults applied when env vars are absent.
+- **Audit failure isolation.** Stub `auditRepo.recordAudit` to return a `Left`; assert the `POST /versions` flow still returns `Right(Unit)` and writes the version (preserved best-effort semantics — R6).
+
+**Performance — out of scope.** No benchmarks required. The optimisations are validated by correctness tests (R3, R4) and qualitative production observation post-deploy.
+
+## Suggested Slice Breakdown
+
+Independently committable, in dependency order. Each slice is a single Conventional Commit.
+
+1. **`chore: drop verbose pgjdbc loglevel from JDBC URL`** — one-line change in `ConfigExtensions.kt`. No test changes. Smallest, safest slice; lands first so subsequent slice verification isn't polluted with driver-level noise.
+2. **`feat: introduce HikariCP connection pool`** — add Hikari dependency in `libs.versions.toml` and `build.gradle.kts`; add `database.pool.*` to `application.conf`; extend `AppConfig`/`DefaultAppConfig`; change `configureDatabase` to build a `HikariDataSource` and pass it to both `Database.connect(dataSource)` and `Flyway.configure().dataSource(ds)`. New unit test for `AppConfig` parsing; new integration test for pool starvation behaviour.
+3. **`refactor: upsert versions to remove create-or-update race`** — replace check-then-act in `PostgresVersionRepository.createOrUpdate` with Exposed `upsert {}` targeting `(candidate, version, distribution, platform)`. New acceptance test for concurrent same-version POSTs (R4). Existing `IdempotentPostVersionAcceptanceSpec` continues to pass.
+4. **`refactor: write version and tags in a single transaction`** — wrap the version+tags work in `VersionServiceImpl.createOrUpdate` in one outer `newSuspendedTransaction`. Keep `logAudit` outside it. New focused test for audit-failure isolation (R6) and single-transaction boundary (R5).
+
+## Verification
+
+After all slices are merged:
+
+- [ ] `./gradlew check` passes cleanly (compile + detekt + ktlint + tests).
+- [ ] `grep -RIn "loglevel" src/main` returns no hits.
+- [ ] HikariCP is the only `DataSource` wired into Exposed and Flyway.
+- [ ] New concurrent-POST acceptance test passes consistently across at least 10 local runs.
+- [ ] Manual smoke: boot against a local Postgres, send 50 concurrent `POST /versions` for the same version, observe all `204` responses and exactly one row in `versions`.
+- [ ] OpenAPI spec confirmed **unchanged** (no endpoint contract changes).
+- [ ] Deployment notes: confirm `DATABASE_POOL_MAX_SIZE` is either unset (default `20`) or set deliberately in the production environment.

--- a/src/main/kotlin/io/sdkman/state/Application.kt
+++ b/src/main/kotlin/io/sdkman/state/Application.kt
@@ -23,8 +23,10 @@ fun main(args: Array<String>) =
 fun Application.module() {
     val appConfig = DefaultAppConfig(environment.config)
 
-    configureDatabaseMigration(appConfig)
-    configureDatabase(appConfig)
+    val dataSource = createHikariDataSource(appConfig)
+    monitor.subscribe(ApplicationStopped) { dataSource.close() }
+    configureDatabaseMigration(dataSource)
+    configureDatabase(dataSource)
 
     configureHTTP()
     configureSerialization()

--- a/src/main/kotlin/io/sdkman/state/Application.kt
+++ b/src/main/kotlin/io/sdkman/state/Application.kt
@@ -2,6 +2,7 @@ package io.sdkman.state
 
 import io.ktor.server.application.*
 import io.sdkman.state.adapter.primary.rest.*
+import io.sdkman.state.adapter.secondary.persistence.ExposedTransactional
 import io.sdkman.state.adapter.secondary.persistence.PostgresAuditRepository
 import io.sdkman.state.adapter.secondary.persistence.PostgresHealthRepository
 import io.sdkman.state.adapter.secondary.persistence.PostgresTagRepository
@@ -37,6 +38,7 @@ fun Application.module() {
     val auditRepo = PostgresAuditRepository()
     val vendorRepo = PostgresVendorRepository()
     val tagService = TagServiceImpl(tagsRepo, auditRepo)
+    val transactional = ExposedTransactional()
     val rateLimiter = RateLimiter()
     launch {
         while (true) {
@@ -49,7 +51,7 @@ fun Application.module() {
     val versionRequestValidator = VersionRequestValidator(appConfig.semverishCandidates)
 
     configureRouting(
-        versionService = VersionServiceImpl(versionsRepo, tagService, auditRepo),
+        versionService = VersionServiceImpl(versionsRepo, tagService, auditRepo, transactional),
         tagService = tagService,
         healthRepo = PostgresHealthRepository(),
         authService = authService,

--- a/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/ExposedTransactional.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/ExposedTransactional.kt
@@ -1,0 +1,20 @@
+package io.sdkman.state.adapter.secondary.persistence
+
+import arrow.core.Either
+import io.sdkman.state.domain.service.Transactional
+import kotlinx.coroutines.Dispatchers
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
+
+/**
+ * Exposed-backed implementation of the [Transactional] port. Wraps the block in a single
+ * `newSuspendedTransaction(Dispatchers.IO)` so nested `dbQuery {}` calls inside [block] reuse the
+ * same JDBC connection (Exposed's default behaviour for nested suspended transactions). On a
+ * `Left` result the explicit `rollback()` flips Exposed's `isRolledBack` flag and rolls back the
+ * underlying JDBC connection so the outer transaction does not commit partial state.
+ */
+class ExposedTransactional : Transactional {
+    override suspend fun <E, A> inTransaction(block: suspend () -> Either<E, A>): Either<E, A> =
+        newSuspendedTransaction(Dispatchers.IO) {
+            block().also { result -> result.onLeft { rollback() } }
+        }
+}

--- a/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepository.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepository.kt
@@ -14,11 +14,12 @@ import io.sdkman.state.domain.repository.TagRepository
 import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInList
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.deleteWhere
-import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.javatime.timestamp
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.upsert
 import java.time.Instant
 
 internal object VersionTagsTable : IntIdTable("version_tags") {
@@ -90,6 +91,16 @@ class PostgresTagRepository : TagRepository {
                 )
             }
 
+    // R5: replaceTags must be race-safe under concurrent same-payload writers. The previous
+    // "delete this version's tags then insert each" had two race windows: (1) the per-tag delete
+    // before insert, (2) the up-front delete-all before any insert. Both let a concurrent writer
+    // observe an empty/partial state and either re-insert (duplicate key) or wipe a sibling
+    // writer's just-inserted row. The replacement is:
+    //   1. Delete only this version's tags that are *not* in the incoming list (so removal still
+    //      works without touching tags we are about to keep).
+    //   2. UPSERT each incoming tag on the `(candidate, tag, distribution, platform)` unique
+    //      index — idempotent on same-payload re-inserts, and atomically re-points the row's
+    //      `version_id` when the tag is being moved from another version in scope.
     override suspend fun replaceTags(
         versionId: Int,
         candidate: String,
@@ -103,24 +114,35 @@ class PostgresTagRepository : TagRepository {
                     val distDb = distributionToDb(distribution)
                     val platformDb = platform.name
 
-                    // Remove all existing tags for this version in this scope
                     VersionTagsTable.deleteWhere {
-                        (VersionTagsTable.versionId eq versionId) and
-                            (VersionTagsTable.candidate eq candidate) and
-                            (VersionTagsTable.distribution eq distDb) and
-                            (VersionTagsTable.platform eq platformDb)
-                    }
-
-                    // For each tag, remove from other versions in the same scope and insert
-                    tags.forEach { tagName ->
-                        VersionTagsTable.deleteWhere {
-                            (VersionTagsTable.candidate eq candidate) and
-                                (VersionTagsTable.tag eq tagName) and
+                        val sameVersionScope =
+                            (VersionTagsTable.versionId eq versionId) and
+                                (VersionTagsTable.candidate eq candidate) and
                                 (VersionTagsTable.distribution eq distDb) and
                                 (VersionTagsTable.platform eq platformDb)
+                        if (tags.isEmpty()) {
+                            sameVersionScope
+                        } else {
+                            sameVersionScope and (VersionTagsTable.tag notInList tags)
                         }
+                    }
 
-                        VersionTagsTable.insert {
+                    tags.forEach { tagName ->
+                        VersionTagsTable.upsert(
+                            VersionTagsTable.candidate,
+                            VersionTagsTable.tag,
+                            VersionTagsTable.distribution,
+                            VersionTagsTable.platform,
+                            onUpdateExclude =
+                                listOf(
+                                    VersionTagsTable.id,
+                                    VersionTagsTable.candidate,
+                                    VersionTagsTable.tag,
+                                    VersionTagsTable.distribution,
+                                    VersionTagsTable.platform,
+                                    VersionTagsTable.createdAt,
+                                ),
+                        ) {
                             it[this.candidate] = candidate
                             it[this.tag] = tagName
                             it[this.distribution] = distDb

--- a/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresVersionRepository.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresVersionRepository.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import arrow.core.Option
 import arrow.core.firstOrNone
 import arrow.core.getOrElse
+import arrow.core.none
 import arrow.core.some
 import arrow.core.toOption
 import io.sdkman.state.domain.error.DatabaseFailure
@@ -21,7 +22,7 @@ import java.time.Instant
 internal object VersionsTable : IntIdTable(name = "versions") {
     val candidate = varchar("candidate", length = 20)
     val version = varchar("version", length = 25)
-    val distribution = varchar("distribution", length = 20).nullable()
+    val distribution = text("distribution")
     val platform = varchar("platform", length = 15)
     val url = varchar("url", length = 500)
     val visible = bool("visible")
@@ -32,6 +33,11 @@ internal object VersionsTable : IntIdTable(name = "versions") {
 }
 
 class PostgresVersionRepository : VersionRepository {
+    private fun distributionToDb(distribution: Option<Distribution>): String = distribution.map { it.name }.getOrElse { NA_SENTINEL }
+
+    private fun dbToDistribution(value: String): Option<Distribution> =
+        if (value == NA_SENTINEL) none() else Distribution.valueOf(value).some()
+
     private fun ResultRow.toVersion(): Version =
         Version(
             candidate = this[VersionsTable.candidate],
@@ -39,7 +45,7 @@ class PostgresVersionRepository : VersionRepository {
             platform = Platform.valueOf(this[VersionsTable.platform]),
             url = this[VersionsTable.url],
             visible = this[VersionsTable.visible].toOption(),
-            distribution = this[VersionsTable.distribution].toOption().map { Distribution.valueOf(it) },
+            distribution = dbToDistribution(this[VersionsTable.distribution]),
             md5sum = this[VersionsTable.md5sum].toOption(),
             sha256sum = this[VersionsTable.sha256sum].toOption(),
             sha512sum = this[VersionsTable.sha512sum].toOption(),
@@ -63,12 +69,6 @@ class PostgresVersionRepository : VersionRepository {
                 .groupBy { it[VersionTagsTable.versionId] }
                 .mapValues { (_, rows) -> rows.map { it[VersionTagsTable.tag] } }
         }
-
-    private fun matchesVersion(cv: Version): Op<Boolean> =
-        (VersionsTable.candidate eq cv.candidate) and
-            (VersionsTable.version eq cv.version) and
-            (cv.distribution.fold({ VersionsTable.distribution eq null }, { VersionsTable.distribution eq it.name })) and
-            (VersionsTable.platform eq cv.platform.name)
 
     override suspend fun findByCandidate(
         candidate: String,
@@ -124,10 +124,7 @@ class PostgresVersionRepository : VersionRepository {
                             (VersionsTable.candidate eq candidate) and
                                 (VersionsTable.version eq version) and
                                 (VersionsTable.platform eq platform.name) and
-                                distribution.fold(
-                                    { VersionsTable.distribution eq null },
-                                    { VersionsTable.distribution eq it.name },
-                                )
+                                (VersionsTable.distribution eq distributionToDb(distribution))
                         }.map { it[VersionsTable.id].value to it.toVersion() }
                         .firstOrNone()
                         .map { (id, v) -> v.withTags(fetchTagNames(id)) }
@@ -139,14 +136,42 @@ class PostgresVersionRepository : VersionRepository {
                 )
             }
 
+    // V15 made versions.distribution NOT NULL with an 'NA' sentinel (mirroring V12's
+    // version_tags shape), so `INSERT … ON CONFLICT (candidate, version, distribution,
+    // platform) DO UPDATE` now applies to every row — Postgres' default NULLS DISTINCT
+    // semantics no longer carve out a deduplication-blind hole for the null-distribution
+    // case. One UPSERT path covers both Some(d) and None inputs.
     override suspend fun createOrUpdate(version: Version): Either<DatabaseFailure, Int> =
         Either
             .catch {
                 dbQuery {
-                    version.distribution.fold(
-                        { createOrUpdateWithoutDistribution(version) },
-                        { dist -> upsertWithDistribution(version, dist) },
-                    )
+                    VersionsTable
+                        .upsert(
+                            VersionsTable.candidate,
+                            VersionsTable.version,
+                            VersionsTable.distribution,
+                            VersionsTable.platform,
+                            onUpdateExclude =
+                                listOf(
+                                    VersionsTable.id,
+                                    VersionsTable.candidate,
+                                    VersionsTable.version,
+                                    VersionsTable.distribution,
+                                    VersionsTable.platform,
+                                ),
+                        ) {
+                            it[candidate] = version.candidate
+                            it[this.version] = version.version
+                            it[distribution] = distributionToDb(version.distribution)
+                            it[platform] = version.platform.name
+                            it[url] = version.url
+                            it[visible] = version.visible.getOrElse { true }
+                            it[md5sum] = version.md5sum.getOrNull()
+                            it[sha256sum] = version.sha256sum.getOrNull()
+                            it[sha512sum] = version.sha512sum.getOrNull()
+                            it[lastUpdatedAt] = Instant.now()
+                        }[VersionsTable.id]
+                        .value
                 }
             }.mapLeft { error ->
                 DatabaseFailure.QueryExecutionFailure(
@@ -155,83 +180,6 @@ class PostgresVersionRepository : VersionRepository {
                 )
             }
 
-    // Postgres `UNIQUE (candidate, version, distribution, platform)` with the distribution column
-    // nullable defaults to NULLS DISTINCT, so `INSERT … ON CONFLICT` cannot deduplicate rows when
-    // distribution is NULL. Keep the check-then-act path for that narrow case; it preserves the
-    // single-writer idempotency the existing acceptance suite relies on. The concurrent race the
-    // spec targets only matters for distribution-bearing payloads, which take the upsert branch.
-    private fun createOrUpdateWithoutDistribution(cv: Version): Int {
-        val exists =
-            VersionsTable
-                .selectAll()
-                .where { matchesVersion(cv) }
-                .empty()
-                .not()
-        return if (exists) updateVersion(cv) else insertVersion(cv)
-    }
-
-    private fun upsertWithDistribution(
-        cv: Version,
-        dist: Distribution,
-    ): Int =
-        VersionsTable
-            .upsert(
-                VersionsTable.candidate,
-                VersionsTable.version,
-                VersionsTable.distribution,
-                VersionsTable.platform,
-                onUpdateExclude =
-                    listOf(
-                        VersionsTable.id,
-                        VersionsTable.candidate,
-                        VersionsTable.version,
-                        VersionsTable.distribution,
-                        VersionsTable.platform,
-                    ),
-            ) {
-                it[candidate] = cv.candidate
-                it[version] = cv.version
-                it[distribution] = dist.name
-                it[platform] = cv.platform.name
-                it[url] = cv.url
-                it[visible] = cv.visible.getOrElse { true }
-                it[md5sum] = cv.md5sum.getOrNull()
-                it[sha256sum] = cv.sha256sum.getOrNull()
-                it[sha512sum] = cv.sha512sum.getOrNull()
-                it[lastUpdatedAt] = Instant.now()
-            }[VersionsTable.id]
-            .value
-
-    private fun updateVersion(cv: Version): Int {
-        VersionsTable.update({ matchesVersion(cv) }) {
-            it[url] = cv.url
-            it[visible] = cv.visible.getOrElse { true }
-            it[md5sum] = cv.md5sum.getOrNull()
-            it[sha256sum] = cv.sha256sum.getOrNull()
-            it[sha512sum] = cv.sha512sum.getOrNull()
-            it[lastUpdatedAt] = Instant.now()
-        }
-        return VersionsTable
-            .select(VersionsTable.id)
-            .where { matchesVersion(cv) }
-            .single()[VersionsTable.id]
-            .value
-    }
-
-    private fun insertVersion(cv: Version): Int =
-        VersionsTable
-            .insertAndGetId {
-                it[candidate] = cv.candidate
-                it[version] = cv.version
-                it[distribution] = cv.distribution.map { d -> d.name }.getOrNull()
-                it[platform] = cv.platform.name
-                it[url] = cv.url
-                it[visible] = cv.visible.getOrElse { true }
-                it[md5sum] = cv.md5sum.getOrNull()
-                it[sha256sum] = cv.sha256sum.getOrNull()
-                it[sha512sum] = cv.sha512sum.getOrNull()
-            }.value
-
     override suspend fun findVersionId(uniqueVersion: UniqueVersion): Either<DatabaseFailure, Option<Int>> =
         Either
             .catch {
@@ -239,16 +187,10 @@ class PostgresVersionRepository : VersionRepository {
                     VersionsTable
                         .select(VersionsTable.id)
                         .where {
-                            val baseCondition =
-                                (VersionsTable.candidate eq uniqueVersion.candidate) and
-                                    (VersionsTable.version eq uniqueVersion.version) and
-                                    (VersionsTable.platform eq uniqueVersion.platform.name)
-                            uniqueVersion.distribution.fold(
-                                { baseCondition and (VersionsTable.distribution eq null) },
-                                { distributionValue ->
-                                    baseCondition and (VersionsTable.distribution eq distributionValue.name)
-                                },
-                            )
+                            (VersionsTable.candidate eq uniqueVersion.candidate) and
+                                (VersionsTable.version eq uniqueVersion.version) and
+                                (VersionsTable.platform eq uniqueVersion.platform.name) and
+                                (VersionsTable.distribution eq distributionToDb(uniqueVersion.distribution))
                         }.map { it[VersionsTable.id].value }
                         .firstOrNone()
                 }
@@ -268,7 +210,7 @@ class PostgresVersionRepository : VersionRepository {
         Either
             .catch {
                 dbQuery {
-                    val distDb = distribution.map { it.name }.getOrElse { NA_SENTINEL }
+                    val distDb = distributionToDb(distribution)
                     VersionTagsTable
                         .join(
                             VersionsTable,
@@ -296,15 +238,10 @@ class PostgresVersionRepository : VersionRepository {
             .catch {
                 dbQuery {
                     VersionsTable.deleteWhere {
-                        val baseCondition =
-                            (candidate eq uniqueVersion.candidate) and
-                                (this.version eq uniqueVersion.version) and
-                                (platform eq uniqueVersion.platform.name)
-
-                        uniqueVersion.distribution.fold(
-                            { baseCondition and (distribution eq null) },
-                            { distributionValue -> baseCondition and (distribution eq distributionValue.name) },
-                        )
+                        (candidate eq uniqueVersion.candidate) and
+                            (this.version eq uniqueVersion.version) and
+                            (platform eq uniqueVersion.platform.name) and
+                            (distribution eq distributionToDb(uniqueVersion.distribution))
                     }
                 }
             }.mapLeft { error ->

--- a/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresVersionRepository.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresVersionRepository.kt
@@ -143,14 +143,10 @@ class PostgresVersionRepository : VersionRepository {
         Either
             .catch {
                 dbQuery {
-                    val exists =
-                        VersionsTable
-                            .selectAll()
-                            .where { matchesVersion(version) }
-                            .empty()
-                            .not()
-
-                    if (exists) updateVersion(version) else insertVersion(version)
+                    version.distribution.fold(
+                        { createOrUpdateWithoutDistribution(version) },
+                        { dist -> upsertWithDistribution(version, dist) },
+                    )
                 }
             }.mapLeft { error ->
                 DatabaseFailure.QueryExecutionFailure(
@@ -158,6 +154,53 @@ class PostgresVersionRepository : VersionRepository {
                     cause = error,
                 )
             }
+
+    // Postgres `UNIQUE (candidate, version, distribution, platform)` with the distribution column
+    // nullable defaults to NULLS DISTINCT, so `INSERT … ON CONFLICT` cannot deduplicate rows when
+    // distribution is NULL. Keep the check-then-act path for that narrow case; it preserves the
+    // single-writer idempotency the existing acceptance suite relies on. The concurrent race the
+    // spec targets only matters for distribution-bearing payloads, which take the upsert branch.
+    private fun createOrUpdateWithoutDistribution(cv: Version): Int {
+        val exists =
+            VersionsTable
+                .selectAll()
+                .where { matchesVersion(cv) }
+                .empty()
+                .not()
+        return if (exists) updateVersion(cv) else insertVersion(cv)
+    }
+
+    private fun upsertWithDistribution(
+        cv: Version,
+        dist: Distribution,
+    ): Int =
+        VersionsTable
+            .upsert(
+                VersionsTable.candidate,
+                VersionsTable.version,
+                VersionsTable.distribution,
+                VersionsTable.platform,
+                onUpdateExclude =
+                    listOf(
+                        VersionsTable.id,
+                        VersionsTable.candidate,
+                        VersionsTable.version,
+                        VersionsTable.distribution,
+                        VersionsTable.platform,
+                    ),
+            ) {
+                it[candidate] = cv.candidate
+                it[version] = cv.version
+                it[distribution] = dist.name
+                it[platform] = cv.platform.name
+                it[url] = cv.url
+                it[visible] = cv.visible.getOrElse { true }
+                it[md5sum] = cv.md5sum.getOrNull()
+                it[sha256sum] = cv.sha256sum.getOrNull()
+                it[sha512sum] = cv.sha512sum.getOrNull()
+                it[lastUpdatedAt] = Instant.now()
+            }[VersionsTable.id]
+            .value
 
     private fun updateVersion(cv: Version): Int {
         VersionsTable.update({ matchesVersion(cv) }) {

--- a/src/main/kotlin/io/sdkman/state/application/service/VersionServiceImpl.kt
+++ b/src/main/kotlin/io/sdkman/state/application/service/VersionServiceImpl.kt
@@ -13,6 +13,7 @@ import io.sdkman.state.domain.model.Version
 import io.sdkman.state.domain.repository.AuditRepository
 import io.sdkman.state.domain.repository.VersionRepository
 import io.sdkman.state.domain.service.TagService
+import io.sdkman.state.domain.service.Transactional
 import io.sdkman.state.domain.service.VersionService
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -21,6 +22,7 @@ class VersionServiceImpl(
     private val versionsRepo: VersionRepository,
     private val tagService: TagService,
     private val auditRepo: AuditRepository,
+    private val transactional: Transactional,
 ) : VersionService {
     private val logger = LoggerFactory.getLogger(VersionServiceImpl::class.java)
 
@@ -54,17 +56,37 @@ class VersionServiceImpl(
             .findByTag(candidate, tag, platform, distribution)
             .mapLeft { DomainError.DatabaseError(it) }
 
+    // R3/R5: the version write and tag replacement run inside a single Transactional block so a
+    // tag-replacement failure rolls back the version write (today they were in separate
+    // transactions, leaving orphan version rows on partial failure). R6: audit logging stays
+    // outside the transaction so an audit failure cannot roll back a successful version write.
     override suspend fun createOrUpdate(
         version: Version,
         vendorId: UUID,
         email: String,
     ): Either<DomainError, Unit> =
-        versionsRepo
-            .createOrUpdate(version)
-            .mapLeft { DomainError.DatabaseError(it) }
-            .map { versionId ->
-                logAudit(vendorId, email, AuditOperation.CREATE, version)
-                processTags(versionId, version)
+        transactional
+            .inTransaction {
+                either {
+                    val versionId =
+                        versionsRepo
+                            .createOrUpdate(version)
+                            .mapLeft { DomainError.DatabaseError(it) }
+                            .bind()
+                    version.tags.onSome { tagList ->
+                        tagService
+                            .replaceTags(
+                                versionId = versionId,
+                                candidate = version.candidate,
+                                distribution = version.distribution,
+                                platform = version.platform,
+                                tags = tagList,
+                            ).bind()
+                    }
+                    Unit
+                }
+            }.also { result ->
+                result.onRight { logAudit(vendorId, email, AuditOperation.CREATE, version) }
             }
 
     override suspend fun delete(
@@ -117,24 +139,6 @@ class VersionServiceImpl(
     ) {
         auditRepo.recordAudit(vendorId, email, operation, data).onLeft { error ->
             logger.warn("Audit logging failed: ${error.message}", error)
-        }
-    }
-
-    private suspend fun processTags(
-        versionId: Int,
-        version: Version,
-    ) {
-        version.tags.onSome { tagList ->
-            tagService
-                .replaceTags(
-                    versionId = versionId,
-                    candidate = version.candidate,
-                    distribution = version.distribution,
-                    platform = version.platform,
-                    tags = tagList,
-                ).onLeft { error ->
-                    logger.warn("Tag processing failed: $error")
-                }
         }
     }
 }

--- a/src/main/kotlin/io/sdkman/state/application/service/VersionServiceImpl.kt
+++ b/src/main/kotlin/io/sdkman/state/application/service/VersionServiceImpl.kt
@@ -2,6 +2,7 @@ package io.sdkman.state.application.service
 
 import arrow.core.Either
 import arrow.core.Option
+import arrow.core.getOrElse
 import arrow.core.raise.either
 import io.sdkman.state.domain.error.DomainError
 import io.sdkman.state.domain.model.AuditOperation
@@ -107,18 +108,7 @@ class VersionServiceImpl(
                     .toEither {
                         DomainError.VersionNotFound(uniqueVersion.candidate, uniqueVersion.version)
                     }.bind()
-            val versionId =
-                versionsRepo
-                    .findVersionId(uniqueVersion)
-                    .mapLeft { DomainError.DatabaseError(it) }
-                    .bind()
-                    .toEither {
-                        DomainError.VersionNotFound(uniqueVersion.candidate, uniqueVersion.version)
-                    }.bind()
-            val tagNames =
-                tagService
-                    .findTagNamesByVersionId(versionId)
-                    .bind()
+            val tagNames = versionToDelete.tags.getOrElse { emptyList() }
             if (tagNames.isNotEmpty()) raise(DomainError.TagConflict(tagNames))
             logAudit(vendorId, email, AuditOperation.DELETE, versionToDelete)
             val deleted =

--- a/src/main/kotlin/io/sdkman/state/config/AppConfig.kt
+++ b/src/main/kotlin/io/sdkman/state/config/AppConfig.kt
@@ -9,6 +9,11 @@ interface AppConfig {
     val databaseName: String
     val databaseUsername: Option<String>
     val databasePassword: Option<String>
+    val databasePoolMaxSize: Int
+    val databasePoolMinIdle: Int
+    val databasePoolConnectionTimeoutMs: Long
+    val databasePoolMaxLifetimeMs: Long
+    val databasePoolIdleTimeoutMs: Long
     val cacheMaxAge: Int
     val adminEmail: String
     val adminPassword: String
@@ -25,6 +30,14 @@ class DefaultAppConfig(
     override val databaseName: String = config.getStringOrDefault("database.name", "sdkman")
     override val databaseUsername: Option<String> = config.getOptionString("database.username")
     override val databasePassword: Option<String> = config.getOptionString("database.password")
+    override val databasePoolMaxSize: Int = config.getIntOrDefault("database.pool.maxSize", 20)
+    override val databasePoolMinIdle: Int = config.getIntOrDefault("database.pool.minIdle", 2)
+    override val databasePoolConnectionTimeoutMs: Long =
+        config.getLongOrDefault("database.pool.connectionTimeoutMs", 5_000L)
+    override val databasePoolMaxLifetimeMs: Long =
+        config.getLongOrDefault("database.pool.maxLifetimeMs", 1_800_000L)
+    override val databasePoolIdleTimeoutMs: Long =
+        config.getLongOrDefault("database.pool.idleTimeoutMs", 600_000L)
     override val cacheMaxAge: Int = config.getIntOrDefault("api.cache.control", 600)
     override val adminEmail: String = config.getStringOrDefault("admin.email", "admin@sdkman.io")
     override val adminPassword: String = config.getStringOrDefault("admin.password", "changeme")

--- a/src/main/kotlin/io/sdkman/state/config/ConfigExtensions.kt
+++ b/src/main/kotlin/io/sdkman/state/config/ConfigExtensions.kt
@@ -15,6 +15,11 @@ fun ApplicationConfig.getIntOrDefault(
     default: Int,
 ): Int = propertyOrNull(path).toOption().map { it.getString().toInt() }.getOrElse { default }
 
+fun ApplicationConfig.getLongOrDefault(
+    path: String,
+    default: Long,
+): Long = propertyOrNull(path).toOption().map { it.getString().toLong() }.getOrElse { default }
+
 fun ApplicationConfig.getOptionString(path: String): Option<String> = propertyOrNull(path).toOption().map { it.getString() }
 
 fun ApplicationConfig.getCommaSeparatedSetOrDefault(

--- a/src/main/kotlin/io/sdkman/state/config/ConfigExtensions.kt
+++ b/src/main/kotlin/io/sdkman/state/config/ConfigExtensions.kt
@@ -38,4 +38,4 @@ fun ApplicationConfig.getCommaSeparatedSetOrDefault(
         }.getOrElse { default }
 
 val AppConfig.jdbcUrl: String
-    get() = "jdbc:postgresql://$databaseHost:$databasePort/$databaseName?sslMode=prefer"
+    get() = "jdbc:postgresql://$databaseHost:$databasePort/$databaseName?sslmode=prefer"

--- a/src/main/kotlin/io/sdkman/state/config/ConfigExtensions.kt
+++ b/src/main/kotlin/io/sdkman/state/config/ConfigExtensions.kt
@@ -33,4 +33,4 @@ fun ApplicationConfig.getCommaSeparatedSetOrDefault(
         }.getOrElse { default }
 
 val AppConfig.jdbcUrl: String
-    get() = "jdbc:postgresql://$databaseHost:$databasePort/$databaseName?sslMode=prefer&loglevel=2"
+    get() = "jdbc:postgresql://$databaseHost:$databasePort/$databaseName?sslMode=prefer"

--- a/src/main/kotlin/io/sdkman/state/config/Databases.kt
+++ b/src/main/kotlin/io/sdkman/state/config/Databases.kt
@@ -1,13 +1,37 @@
 package io.sdkman.state.config
 
 import arrow.core.getOrElse
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
 import io.ktor.server.application.*
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
+import java.sql.Connection
+import javax.sql.DataSource
 
-fun Application.configureDatabase(config: AppConfig) =
+fun createHikariDataSource(config: AppConfig): HikariDataSource {
+    val hikariConfig =
+        HikariConfig().apply {
+            jdbcUrl = config.jdbcUrl
+            username = config.databaseUsername.getOrElse { "" }
+            password = config.databasePassword.getOrElse { "" }
+            driverClassName = "org.postgresql.Driver"
+            maximumPoolSize = config.databasePoolMaxSize
+            minimumIdle = config.databasePoolMinIdle
+            connectionTimeout = config.databasePoolConnectionTimeoutMs
+            maxLifetime = config.databasePoolMaxLifetimeMs
+            idleTimeout = config.databasePoolIdleTimeoutMs
+            poolName = "sdkman-state-pool"
+            initializationFailTimeout = -1
+        }
+    return HikariDataSource(hikariConfig)
+}
+
+fun Application.configureDatabase(dataSource: DataSource): Database =
     Database.connect(
-        url = config.jdbcUrl,
-        user = config.databaseUsername.getOrElse { "" },
-        password = config.databasePassword.getOrElse { "" },
-        driver = "org.postgresql.Driver",
+        datasource = dataSource,
+        databaseConfig =
+            DatabaseConfig {
+                defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED
+            },
     )

--- a/src/main/kotlin/io/sdkman/state/config/Migration.kt
+++ b/src/main/kotlin/io/sdkman/state/config/Migration.kt
@@ -1,16 +1,13 @@
 package io.sdkman.state.config
 
-import arrow.core.getOrElse
 import io.ktor.server.application.*
 import org.flywaydb.core.Flyway
+import javax.sql.DataSource
 
-fun Application.configureDatabaseMigration(config: AppConfig) {
+fun Application.configureDatabaseMigration(dataSource: DataSource) {
     Flyway
         .configure()
-        .dataSource(
-            config.jdbcUrl,
-            config.databaseUsername.getOrElse { "" },
-            config.databasePassword.getOrElse { "" },
-        ).load()
+        .dataSource(dataSource)
+        .load()
         .migrate()
 }

--- a/src/main/kotlin/io/sdkman/state/domain/service/Transactional.kt
+++ b/src/main/kotlin/io/sdkman/state/domain/service/Transactional.kt
@@ -1,0 +1,18 @@
+package io.sdkman.state.domain.service
+
+import arrow.core.Either
+
+/**
+ * Application-level port that runs a block inside a single database transaction.
+ *
+ * Required by spec R3/R5: `POST /versions` must perform the version write and tag replacement
+ * inside one transaction so a tag-replacement failure rolls back the version write. Defined here
+ * (in the domain) so application services do not import Exposed directly — the infrastructure
+ * adapter lives in `adapter.secondary.persistence`.
+ *
+ * Contract: if [block] returns `Either.Left`, the implementation MUST roll back. If it returns
+ * `Either.Right`, the implementation MUST commit. Exceptions thrown by [block] also roll back.
+ */
+interface Transactional {
+    suspend fun <E, A> inTransaction(block: suspend () -> Either<E, A>): Either<E, A>
+}

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -17,6 +17,19 @@ database {
     username = ${?DATABASE_USERNAME}
     password = "postgres"
     password = ${?DATABASE_PASSWORD}
+
+    pool {
+        maxSize = 20
+        maxSize = ${?DATABASE_POOL_MAX_SIZE}
+        minIdle = 2
+        minIdle = ${?DATABASE_POOL_MIN_IDLE}
+        connectionTimeoutMs = 5000
+        connectionTimeoutMs = ${?DATABASE_POOL_CONNECTION_TIMEOUT_MS}
+        maxLifetimeMs = 1800000
+        maxLifetimeMs = ${?DATABASE_POOL_MAX_LIFETIME_MS}
+        idleTimeoutMs = 600000
+        idleTimeoutMs = ${?DATABASE_POOL_IDLE_TIMEOUT_MS}
+    }
 }
 
 api {

--- a/src/main/resources/db/migration/V15__make_versions_distribution_not_null.sql
+++ b/src/main/resources/db/migration/V15__make_versions_distribution_not_null.sql
@@ -1,0 +1,12 @@
+-- Make versions.distribution NOT NULL with an 'NA' sentinel, mirroring the
+-- version_tags shape introduced in V12. Removing the NULL state lets
+-- PostgresVersionRepository.createOrUpdate fold its two code paths into a
+-- single UPSERT: Postgres' default NULLS DISTINCT semantics no longer carve
+-- out a deduplication-blind hole for distribution-less rows, so
+-- INSERT … ON CONFLICT (candidate, version, distribution, platform) DO UPDATE
+-- now fires on every row.
+
+UPDATE versions SET distribution = 'NA' WHERE distribution IS NULL;
+
+ALTER TABLE versions ALTER COLUMN distribution SET DEFAULT 'NA';
+ALTER TABLE versions ALTER COLUMN distribution SET NOT NULL;

--- a/src/test/kotlin/io/sdkman/state/acceptance/ConcurrentPostVersionAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/ConcurrentPostVersionAcceptanceSpec.kt
@@ -1,0 +1,96 @@
+package io.sdkman.state.acceptance
+
+import arrow.core.some
+import io.kotest.assertions.withClue
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.sdkman.state.adapter.secondary.persistence.VersionsTable
+import io.sdkman.state.adapter.secondary.persistence.dbQuery
+import io.sdkman.state.domain.model.Distribution
+import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.Version
+import io.sdkman.state.support.JwtTestSupport
+import io.sdkman.state.support.toJsonString
+import io.sdkman.state.support.withCleanDatabase
+import io.sdkman.state.support.withTestApplication
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.selectAll
+
+/**
+ * Guards spec R4: concurrent POST /versions for the same (candidate, version, distribution, platform)
+ * must collapse to a single row via the Postgres UPSERT, with every caller seeing 204 No Content
+ * (i.e. no unique-constraint exception ever leaks back to the client).
+ *
+ * Run repeatedly (`./gradlew test --tests '*ConcurrentPostVersion*' --rerun`) to flush out any
+ * surviving check-then-act race window.
+ */
+@Tags("acceptance")
+class ConcurrentPostVersionAcceptanceSpec :
+    ShouldSpec({
+
+        should("collapse concurrent POST /versions for the same payload into a single row") {
+            val version =
+                Version(
+                    candidate = "java",
+                    version = "21.0.4",
+                    platform = Platform.LINUX_X64,
+                    url = "https://java-21.0.4-temurin",
+                    visible = true.some(),
+                    distribution = Distribution.TEMURIN.some(),
+                    md5sum = "abc123def456abc123def456abc123de".some(),
+                )
+            val requestBody = version.toJsonString()
+            val concurrentRequests = 20
+
+            withCleanDatabase {
+                withTestApplication {
+                    val token = JwtTestSupport.adminToken()
+                    val statuses =
+                        coroutineScope {
+                            (1..concurrentRequests)
+                                .map {
+                                    async {
+                                        client
+                                            .post("/versions") {
+                                                contentType(ContentType.Application.Json)
+                                                setBody(requestBody)
+                                                bearerAuth(token)
+                                            }.status
+                                    }
+                                }.awaitAll()
+                        }
+
+                    withClue("every concurrent POST should return 204 NoContent") {
+                        statuses.toSet() shouldBe setOf(HttpStatusCode.NoContent)
+                    }
+                }
+
+                val rowCount =
+                    dbQuery {
+                        VersionsTable
+                            .selectAll()
+                            .where {
+                                (VersionsTable.candidate eq version.candidate) and
+                                    (VersionsTable.version eq version.version) and
+                                    (VersionsTable.distribution eq Distribution.TEMURIN.name) and
+                                    (VersionsTable.platform eq version.platform.name)
+                            }.count()
+                    }
+
+                withClue("upsert must collapse $concurrentRequests concurrent writes into one row") {
+                    rowCount shouldBe 1L
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/io/sdkman/state/acceptance/ConcurrentPostVersionWithTagsAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/ConcurrentPostVersionWithTagsAcceptanceSpec.kt
@@ -1,0 +1,114 @@
+package io.sdkman.state.acceptance
+
+import arrow.core.some
+import io.kotest.assertions.withClue
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.sdkman.state.adapter.secondary.persistence.VersionTagsTable
+import io.sdkman.state.adapter.secondary.persistence.VersionsTable
+import io.sdkman.state.adapter.secondary.persistence.dbQuery
+import io.sdkman.state.domain.model.Distribution
+import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.Version
+import io.sdkman.state.support.JwtTestSupport
+import io.sdkman.state.support.toJsonString
+import io.sdkman.state.support.withCleanDatabase
+import io.sdkman.state.support.withTestApplication
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.selectAll
+
+/**
+ * Guards spec R5: the version write and the tag replacement run in a single transaction so a
+ * tag-replacement failure rolls back the version write — and, equally, concurrent same-payload
+ * writes never leave orphan or duplicate tag rows behind. Fires N coroutines posting the same
+ * `(candidate, version, distribution, platform)` payload **with tags**, asserts every response
+ * is 204 No Content, then verifies that exactly one version row survives and the surviving tag
+ * rows match the posted tag list (no orphan rows from partially-applied attempts).
+ */
+@Tags("acceptance")
+class ConcurrentPostVersionWithTagsAcceptanceSpec :
+    ShouldSpec({
+
+        should("collapse concurrent POST /versions with tags into a single row and tag set") {
+            val tags = listOf("latest", "lts", "21")
+            val version =
+                Version(
+                    candidate = "java",
+                    version = "21.0.5",
+                    platform = Platform.LINUX_X64,
+                    url = "https://java-21.0.5-temurin",
+                    visible = true.some(),
+                    distribution = Distribution.TEMURIN.some(),
+                    tags = tags.some(),
+                )
+            val requestBody = version.toJsonString()
+            val concurrentRequests = 20
+
+            withCleanDatabase {
+                withTestApplication {
+                    val token = JwtTestSupport.adminToken()
+                    val statuses =
+                        coroutineScope {
+                            (1..concurrentRequests)
+                                .map {
+                                    async {
+                                        client
+                                            .post("/versions") {
+                                                contentType(ContentType.Application.Json)
+                                                setBody(requestBody)
+                                                bearerAuth(token)
+                                            }.status
+                                    }
+                                }.awaitAll()
+                        }
+
+                    withClue("every concurrent POST should return 204 NoContent") {
+                        statuses.toSet() shouldBe setOf(HttpStatusCode.NoContent)
+                    }
+                }
+
+                val rowCount =
+                    dbQuery {
+                        VersionsTable
+                            .selectAll()
+                            .where {
+                                (VersionsTable.candidate eq version.candidate) and
+                                    (VersionsTable.version eq version.version) and
+                                    (VersionsTable.distribution eq Distribution.TEMURIN.name) and
+                                    (VersionsTable.platform eq version.platform.name)
+                            }.count()
+                    }
+
+                withClue("upsert must collapse $concurrentRequests concurrent writes into one row") {
+                    rowCount shouldBe 1L
+                }
+
+                val tagRows =
+                    dbQuery {
+                        VersionTagsTable
+                            .selectAll()
+                            .where {
+                                (VersionTagsTable.candidate eq version.candidate) and
+                                    (VersionTagsTable.distribution eq Distribution.TEMURIN.name) and
+                                    (VersionTagsTable.platform eq version.platform.name)
+                            }.map { it[VersionTagsTable.tag] to it[VersionTagsTable.versionId] }
+                    }
+
+                withClue("tag rows must match the single surviving write — no orphans, no duplicates") {
+                    tagRows.map { it.first }.sorted() shouldBe tags.sorted()
+                    tagRows.map { it.second }.toSet().size shouldBe 1
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/io/sdkman/state/acceptance/ConcurrentPostVersionWithoutDistributionAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/ConcurrentPostVersionWithoutDistributionAcceptanceSpec.kt
@@ -1,0 +1,95 @@
+package io.sdkman.state.acceptance
+
+import arrow.core.none
+import arrow.core.some
+import io.kotest.assertions.withClue
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.bearerAuth
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import io.sdkman.state.adapter.secondary.persistence.NA_SENTINEL
+import io.sdkman.state.adapter.secondary.persistence.VersionsTable
+import io.sdkman.state.adapter.secondary.persistence.dbQuery
+import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.Version
+import io.sdkman.state.support.JwtTestSupport
+import io.sdkman.state.support.toJsonString
+import io.sdkman.state.support.withCleanDatabase
+import io.sdkman.state.support.withTestApplication
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.selectAll
+
+/**
+ * Guards the value of V15 (versions.distribution NOT NULL with 'NA' sentinel): the no-distribution
+ * branch of POST /versions must now also collapse concurrent same-payload writes into a single row.
+ * Pre-V15 this branch used check-then-act because Postgres' default NULLS DISTINCT semantics
+ * defeated INSERT … ON CONFLICT for null-distribution rows. Post-V15 the column is non-null and the
+ * UPSERT applies uniformly.
+ */
+@Tags("acceptance")
+class ConcurrentPostVersionWithoutDistributionAcceptanceSpec :
+    ShouldSpec({
+
+        should("collapse concurrent POST /versions for the same no-distribution payload into a single row") {
+            val version =
+                Version(
+                    candidate = "scala",
+                    version = "3.4.0",
+                    platform = Platform.UNIVERSAL,
+                    url = "https://scala-3.4.0",
+                    visible = true.some(),
+                    distribution = none(),
+                )
+            val requestBody = version.toJsonString()
+            val concurrentRequests = 20
+
+            withCleanDatabase {
+                withTestApplication {
+                    val token = JwtTestSupport.adminToken()
+                    val statuses =
+                        coroutineScope {
+                            (1..concurrentRequests)
+                                .map {
+                                    async {
+                                        client
+                                            .post("/versions") {
+                                                contentType(ContentType.Application.Json)
+                                                setBody(requestBody)
+                                                bearerAuth(token)
+                                            }.status
+                                    }
+                                }.awaitAll()
+                        }
+
+                    withClue("every concurrent no-distribution POST should return 204 NoContent") {
+                        statuses.toSet() shouldBe setOf(HttpStatusCode.NoContent)
+                    }
+                }
+
+                val rowCount =
+                    dbQuery {
+                        VersionsTable
+                            .selectAll()
+                            .where {
+                                (VersionsTable.candidate eq version.candidate) and
+                                    (VersionsTable.version eq version.version) and
+                                    (VersionsTable.distribution eq NA_SENTINEL) and
+                                    (VersionsTable.platform eq version.platform.name)
+                            }.count()
+                    }
+
+                withClue("upsert must collapse $concurrentRequests concurrent no-distribution writes into one row") {
+                    rowCount shouldBe 1L
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/io/sdkman/state/acceptance/HealthCheckAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/HealthCheckAcceptanceSpec.kt
@@ -14,6 +14,7 @@ import io.ktor.server.testing.*
 import io.sdkman.state.adapter.primary.rest.configureRouting
 import io.sdkman.state.adapter.primary.rest.configureSerialization
 import io.sdkman.state.adapter.primary.rest.dto.HealthCheckResponse
+import io.sdkman.state.adapter.secondary.persistence.ExposedTransactional
 import io.sdkman.state.adapter.secondary.persistence.PostgresAuditRepository
 import io.sdkman.state.adapter.secondary.persistence.PostgresHealthRepository
 import io.sdkman.state.adapter.secondary.persistence.PostgresTagRepository
@@ -92,11 +93,12 @@ class HealthCheckAcceptanceSpec :
                         val auditRepo = PostgresAuditRepository()
                         val vendorRepo = PostgresVendorRepository()
                         val tagService = TagServiceImpl(tagsRepo, auditRepo)
+                        val transactional = ExposedTransactional()
                         val rateLimiter = RateLimiter()
                         val authService = AuthServiceImpl(vendorRepo, appConfig, rateLimiter)
 
                         configureRouting(
-                            versionService = VersionServiceImpl(versionsRepo, tagService, auditRepo),
+                            versionService = VersionServiceImpl(versionsRepo, tagService, auditRepo, transactional),
                             tagService = tagService,
                             healthRepo = PostgresHealthRepository(),
                             authService = authService,

--- a/src/test/kotlin/io/sdkman/state/acceptance/HealthCheckAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/HealthCheckAcceptanceSpec.kt
@@ -26,11 +26,17 @@ import io.sdkman.state.application.service.VersionServiceImpl
 import io.sdkman.state.application.validation.VersionRequestValidator
 import io.sdkman.state.config.AppConfig
 import io.sdkman.state.config.DefaultAppConfig
-import io.sdkman.state.config.configureDatabase
 import io.sdkman.state.config.configureJwtAuthentication
+import io.sdkman.state.config.createHikariDataSource
+import io.sdkman.state.support.sharedTestDatabase
 import io.sdkman.state.support.testApplicationConfig
 import io.sdkman.state.support.withCleanDatabase
+import io.sdkman.state.support.withTestApplication
 import kotlinx.serialization.json.Json
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+import java.sql.Connection
 
 @Tags("acceptance")
 class HealthCheckAcceptanceSpec :
@@ -38,13 +44,46 @@ class HealthCheckAcceptanceSpec :
 
         should("return SUCCESS status when database is available") {
             withCleanDatabase {
+                withTestApplication {
+                    client.get("/meta/health").apply {
+                        status shouldBe HttpStatusCode.OK
+                        contentType()
+                            .toOption()
+                            .map { it.withoutParameters() }
+                            .getOrElse { error("no content type") } shouldBe ContentType.Application.Json
+
+                        val response = Json.decodeFromString<HealthCheckResponse>(bodyAsText())
+                        response.status shouldBe "SUCCESS"
+                        response.message shouldBe none()
+                    }
+                }
+            }
+        }
+
+        should("return FAILURE status when database is unavailable") {
+            val appConfig = DefaultAppConfig(testApplicationConfig())
+            val badAppConfig =
+                object : AppConfig by appConfig {
+                    override val databasePort: Int = 9999
+                    override val databasePoolConnectionTimeoutMs: Long = 1_000L
+                    override val databasePoolMaxSize: Int = 1
+                    override val databasePoolMinIdle: Int = 0
+                }
+            val badDataSource = createHikariDataSource(badAppConfig)
+            val badDatabase =
+                Database.connect(
+                    datasource = badDataSource,
+                    databaseConfig =
+                        DatabaseConfig {
+                            defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED
+                        },
+                )
+            try {
                 testApplication {
                     environment {
                         config = testApplicationConfig()
                     }
                     application {
-                        val appConfig = DefaultAppConfig(environment.config)
-                        configureDatabase(appConfig)
                         configureSerialization()
                         configureJwtAuthentication(appConfig)
 
@@ -68,67 +107,24 @@ class HealthCheckAcceptanceSpec :
                     }
 
                     client.get("/meta/health").apply {
-                        status shouldBe HttpStatusCode.OK
+                        status shouldBe HttpStatusCode.ServiceUnavailable
                         contentType()
                             .toOption()
                             .map { it.withoutParameters() }
                             .getOrElse { error("no content type") } shouldBe ContentType.Application.Json
 
                         val response = Json.decodeFromString<HealthCheckResponse>(bodyAsText())
-                        response.status shouldBe "SUCCESS"
-                        response.message shouldBe none()
+                        response.status shouldBe "FAILURE"
+                        response.message
+                            .map { it shouldContain "Database connection failed" }
+                            .getOrElse { error("no message for failure") }
                     }
                 }
-            }
-        }
-
-        should("return FAILURE status when database is unavailable") {
-            testApplication {
-                environment {
-                    config = testApplicationConfig()
-                }
-                application {
-                    val appConfig = DefaultAppConfig(environment.config)
-                    val badAppConfig =
-                        object : AppConfig by appConfig {
-                            override val databasePort: Int = 9999
-                        }
-                    configureDatabase(badAppConfig)
-                    configureSerialization()
-                    configureJwtAuthentication(appConfig)
-
-                    val versionsRepo = PostgresVersionRepository()
-                    val tagsRepo = PostgresTagRepository()
-                    val auditRepo = PostgresAuditRepository()
-                    val vendorRepo = PostgresVendorRepository()
-                    val tagService = TagServiceImpl(tagsRepo, auditRepo)
-                    val rateLimiter = RateLimiter()
-                    val authService = AuthServiceImpl(vendorRepo, appConfig, rateLimiter)
-
-                    configureRouting(
-                        versionService = VersionServiceImpl(versionsRepo, tagService, auditRepo),
-                        tagService = tagService,
-                        healthRepo = PostgresHealthRepository(),
-                        authService = authService,
-                        vendorRepository = vendorRepo,
-                        appConfig = appConfig,
-                        versionRequestValidator = VersionRequestValidator(appConfig.semverishCandidates),
-                    )
-                }
-
-                client.get("/meta/health").apply {
-                    status shouldBe HttpStatusCode.ServiceUnavailable
-                    contentType()
-                        .toOption()
-                        .map { it.withoutParameters() }
-                        .getOrElse { error("no content type") } shouldBe ContentType.Application.Json
-
-                    val response = Json.decodeFromString<HealthCheckResponse>(bodyAsText())
-                    response.status shouldBe "FAILURE"
-                    response.message
-                        .map { it shouldContain "Database connection failed" }
-                        .getOrElse { error("no message for failure") }
-                }
+            } finally {
+                TransactionManager.closeAndUnregister(badDatabase)
+                badDataSource.close()
+                // Re-prime the shared default so subsequent specs use the working pool.
+                sharedTestDatabase
             }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/application/service/VersionServiceUnitSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/application/service/VersionServiceUnitSpec.kt
@@ -328,7 +328,47 @@ class VersionServiceUnitSpec :
         context("delete") {
 
             should("delete version when it exists and has no tags") {
-                // given: version exists and has no tags
+                // given: version exists with an empty tag list (as findUnique populates after fetch)
+                val uniqueVersion =
+                    UniqueVersion(
+                        candidate = "java",
+                        version = "17.0.1",
+                        distribution = none(),
+                        platform = Platform.LINUX_X64,
+                    )
+                val version =
+                    Version(
+                        candidate = "java",
+                        version = "17.0.1",
+                        platform = Platform.LINUX_X64,
+                        url = "https://example.com/java-17.tar.gz",
+                        tags = emptyList<String>().some(),
+                    )
+                coEvery {
+                    versionsRepo.findUnique("java", "17.0.1", Platform.LINUX_X64, none())
+                } returns Either.Right(version.some())
+                coEvery {
+                    auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.DELETE, version)
+                } returns Either.Right(Unit)
+                coEvery { versionsRepo.delete(uniqueVersion) } returns Either.Right(1)
+
+                // when: deleting the version
+                val result = service.delete(uniqueVersion, NIL_UUID, "admin")
+
+                // then: succeeds via a single findUnique + delete pair (no redundant id/tag lookups)
+                result.shouldBeRight()
+                coVerify(ordering = io.mockk.Ordering.ORDERED) {
+                    versionsRepo.findUnique("java", "17.0.1", Platform.LINUX_X64, none())
+                    auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.DELETE, version)
+                    versionsRepo.delete(uniqueVersion)
+                }
+                coVerify(exactly = 0) { versionsRepo.findVersionId(any()) }
+                coVerify(exactly = 0) { tagService.findTagNamesByVersionId(any()) }
+            }
+
+            should("treat findUnique's None tags as no-tag for the conflict check") {
+                // given: findUnique returns a version whose tags is None (defensive — production path
+                // always populates Some(list), but the domain model default is none())
                 val uniqueVersion =
                     UniqueVersion(
                         candidate = "java",
@@ -346,25 +386,16 @@ class VersionServiceUnitSpec :
                 coEvery {
                     versionsRepo.findUnique("java", "17.0.1", Platform.LINUX_X64, none())
                 } returns Either.Right(version.some())
-                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(42.some())
-                coEvery { tagService.findTagNamesByVersionId(42) } returns Either.Right(emptyList())
                 coEvery {
                     auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.DELETE, version)
                 } returns Either.Right(Unit)
                 coEvery { versionsRepo.delete(uniqueVersion) } returns Either.Right(1)
 
-                // when: deleting the version
+                // when
                 val result = service.delete(uniqueVersion, NIL_UUID, "admin")
 
-                // then: succeeds
+                // then: succeeds — getOrElse { emptyList() } collapses None to no conflict
                 result.shouldBeRight()
-                coVerify(ordering = io.mockk.Ordering.ORDERED) {
-                    versionsRepo.findUnique("java", "17.0.1", Platform.LINUX_X64, none())
-                    versionsRepo.findVersionId(uniqueVersion)
-                    tagService.findTagNamesByVersionId(42)
-                    auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.DELETE, version)
-                    versionsRepo.delete(uniqueVersion)
-                }
             }
 
             should("return VersionNotFound when version does not exist") {
@@ -393,40 +424,9 @@ class VersionServiceUnitSpec :
                 coVerify(exactly = 0) { versionsRepo.delete(any()) }
             }
 
-            should("return VersionNotFound when version ID is not found") {
-                // given: version exists but ID lookup returns none()
-                val uniqueVersion =
-                    UniqueVersion(
-                        candidate = "java",
-                        version = "17.0.1",
-                        distribution = none(),
-                        platform = Platform.LINUX_X64,
-                    )
-                val version =
-                    Version(
-                        candidate = "java",
-                        version = "17.0.1",
-                        platform = Platform.LINUX_X64,
-                        url = "https://example.com/java-17.tar.gz",
-                    )
-                coEvery {
-                    versionsRepo.findUnique("java", "17.0.1", Platform.LINUX_X64, none())
-                } returns Either.Right(version.some())
-                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(none())
-
-                // when: trying to delete with missing version ID
-                val result = service.delete(uniqueVersion, NIL_UUID, "admin")
-
-                // then: returns VersionNotFound
-                result.shouldBeLeft()
-                result.onLeft { error ->
-                    error.shouldBeInstanceOf<DomainError.VersionNotFound>()
-                }
-                coVerify(exactly = 0) { versionsRepo.delete(any()) }
-            }
-
             should("return TagConflict when version has active tags") {
-                // given: version has active tags
+                // given: findUnique returns a version whose tags are already populated (mirrors
+                // production — PostgresVersionRepository.findUnique applies withTags(fetchTagNames(id)))
                 val uniqueVersion =
                     UniqueVersion(
                         candidate = "java",
@@ -440,19 +440,17 @@ class VersionServiceUnitSpec :
                         version = "17.0.1",
                         platform = Platform.LINUX_X64,
                         url = "https://example.com/java-17.tar.gz",
+                        tags = listOf("lts", "latest").some(),
                     )
                 coEvery {
                     versionsRepo.findUnique("java", "17.0.1", Platform.LINUX_X64, none())
                 } returns Either.Right(version.some())
-                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(42.some())
-                coEvery {
-                    tagService.findTagNamesByVersionId(42)
-                } returns Either.Right(listOf("lts", "latest"))
 
                 // when: trying to delete a version with active tags
                 val result = service.delete(uniqueVersion, NIL_UUID, "admin")
 
-                // then: returns TagConflict with the tag names
+                // then: returns TagConflict with the tag names — taken directly from the fetched
+                // version, no extra DB lookup required
                 result.shouldBeLeft()
                 result.onLeft { error ->
                     error.shouldBeInstanceOf<DomainError.TagConflict>()
@@ -460,23 +458,17 @@ class VersionServiceUnitSpec :
                 }
                 coVerify(exactly = 0) { versionsRepo.delete(any()) }
                 coVerify(exactly = 0) { auditRepo.recordAudit(any(), any(), any(), any()) }
+                coVerify(exactly = 0) { tagService.findTagNamesByVersionId(any()) }
             }
 
-            should("return DatabaseError when tag lookup fails") {
-                // given: tag lookup fails with a database error
+            should("return DatabaseError when findUnique fails") {
+                // given: findUnique fails with a database error
                 val uniqueVersion =
                     UniqueVersion(
                         candidate = "java",
                         version = "17.0.1",
                         distribution = none(),
                         platform = Platform.LINUX_X64,
-                    )
-                val version =
-                    Version(
-                        candidate = "java",
-                        version = "17.0.1",
-                        platform = Platform.LINUX_X64,
-                        url = "https://example.com/java-17.tar.gz",
                     )
                 val dbFailure =
                     DatabaseFailure.QueryExecutionFailure(
@@ -485,13 +477,9 @@ class VersionServiceUnitSpec :
                     )
                 coEvery {
                     versionsRepo.findUnique("java", "17.0.1", Platform.LINUX_X64, none())
-                } returns Either.Right(version.some())
-                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(42.some())
-                coEvery {
-                    tagService.findTagNamesByVersionId(42)
-                } returns Either.Left(DomainError.DatabaseError(dbFailure))
+                } returns Either.Left(dbFailure)
 
-                // when: deleting a version when tag lookup fails
+                // when: deleting a version when the lookup fails
                 val result = service.delete(uniqueVersion, NIL_UUID, "admin")
 
                 // then: returns DatabaseError
@@ -518,12 +506,11 @@ class VersionServiceUnitSpec :
                         version = "17.0.1",
                         platform = Platform.LINUX_X64,
                         url = "https://example.com/java-17.tar.gz",
+                        tags = emptyList<String>().some(),
                     )
                 coEvery {
                     versionsRepo.findUnique("java", "17.0.1", Platform.LINUX_X64, none())
                 } returns Either.Right(version.some())
-                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(42.some())
-                coEvery { tagService.findTagNamesByVersionId(42) } returns Either.Right(emptyList())
                 coEvery {
                     auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.DELETE, version)
                 } returns Either.Right(Unit)

--- a/src/test/kotlin/io/sdkman/state/application/service/VersionServiceUnitSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/application/service/VersionServiceUnitSpec.kt
@@ -21,18 +21,29 @@ import io.sdkman.state.domain.model.Version
 import io.sdkman.state.domain.repository.AuditRepository
 import io.sdkman.state.domain.repository.VersionRepository
 import io.sdkman.state.domain.service.TagService
+import io.sdkman.state.domain.service.Transactional
 import io.sdkman.state.support.shouldBeLeft
 import io.sdkman.state.support.shouldBeRight
 import java.util.UUID
 
 private val NIL_UUID: UUID = UUID(0L, 0L)
 
+/**
+ * Passthrough used so unit tests can exercise [VersionServiceImpl.createOrUpdate] without a
+ * registered Exposed `Database`. Production uses `ExposedTransactional`; verifying the wrapping
+ * call count from the service is covered by [transactional] being a mockk spy below.
+ */
+private fun passthroughTransactional(): Transactional =
+    object : Transactional {
+        override suspend fun <E, A> inTransaction(block: suspend () -> Either<E, A>): Either<E, A> = block()
+    }
+
 class VersionServiceUnitSpec :
     ShouldSpec({
         val versionsRepo = mockk<VersionRepository>()
         val tagService = mockk<TagService>()
         val auditRepo = mockk<AuditRepository>()
-        val service = VersionServiceImpl(versionsRepo, tagService, auditRepo)
+        val service = VersionServiceImpl(versionsRepo, tagService, auditRepo, passthroughTransactional())
 
         beforeEach { clearAllMocks() }
 
@@ -242,8 +253,11 @@ class VersionServiceUnitSpec :
                 result.shouldBeRight()
             }
 
-            should("still succeed when tag processing fails") {
-                // given: tag processing fails but create succeeds
+            should("return DatabaseError and skip audit when tag processing fails") {
+                // R5: tag replacement is atomic with the version write — if tags fail, the
+                // version write rolls back and the request must surface the failure (no more
+                // silent swallow). Audit must also be skipped because the version write was
+                // rolled back, so there is no successful operation to record.
                 val version =
                     Version(
                         candidate = "java",
@@ -252,27 +266,62 @@ class VersionServiceUnitSpec :
                         url = "https://example.com/java-17.tar.gz",
                         tags = listOf("lts").some(),
                     )
-                coEvery { versionsRepo.createOrUpdate(version) } returns Either.Right(42)
-                coEvery {
-                    auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.CREATE, version)
-                } returns Either.Right(Unit)
-                coEvery {
-                    tagService.replaceTags(42, "java", none(), Platform.LINUX_X64, listOf("lts"))
-                } returns
-                    Either.Left(
-                        DomainError.DatabaseError(
-                            DatabaseFailure.QueryExecutionFailure(
-                                "tag error",
-                                RuntimeException("tag failure"),
-                            ),
+                val tagFailure =
+                    DomainError.DatabaseError(
+                        DatabaseFailure.QueryExecutionFailure(
+                            "tag error",
+                            RuntimeException("tag failure"),
                         ),
                     )
+                coEvery { versionsRepo.createOrUpdate(version) } returns Either.Right(42)
+                coEvery {
+                    tagService.replaceTags(42, "java", none(), Platform.LINUX_X64, listOf("lts"))
+                } returns Either.Left(tagFailure)
 
                 // when: creating a version with failing tag processing
                 val result = service.createOrUpdate(version, NIL_UUID, "admin")
 
-                // then: still succeeds (tag failure is logged but non-fatal)
-                result.shouldBeRight()
+                // then: surfaces the tag failure and never touches audit
+                result.shouldBeLeft()
+                result.onLeft { it shouldBe tagFailure }
+                coVerify(exactly = 0) {
+                    auditRepo.recordAudit(any(), any(), any(), any())
+                }
+            }
+
+            should("roll back the outer transaction when tag processing fails") {
+                // R5: the version+tag write must run in one transaction. Verify by spying on the
+                // Transactional port — it should be called exactly once, and a Left bubbled out
+                // of its block must reach the caller unchanged.
+                val transactional = mockk<Transactional>()
+                val txService = VersionServiceImpl(versionsRepo, tagService, auditRepo, transactional)
+                val version =
+                    Version(
+                        candidate = "java",
+                        version = "17.0.1",
+                        platform = Platform.LINUX_X64,
+                        url = "https://example.com/java-17.tar.gz",
+                        tags = listOf("lts").some(),
+                    )
+                val tagFailure =
+                    DomainError.DatabaseError(
+                        DatabaseFailure.QueryExecutionFailure("tag error", RuntimeException("x")),
+                    )
+                coEvery { versionsRepo.createOrUpdate(version) } returns Either.Right(42)
+                coEvery {
+                    tagService.replaceTags(42, "java", none(), Platform.LINUX_X64, listOf("lts"))
+                } returns Either.Left(tagFailure)
+                coEvery { transactional.inTransaction<DomainError, Unit>(any()) } coAnswers {
+                    val block = firstArg<suspend () -> Either<DomainError, Unit>>()
+                    block()
+                }
+
+                // when: the version write succeeds but tag replacement fails
+                val result = txService.createOrUpdate(version, NIL_UUID, "admin")
+
+                // then: the failure is returned and inTransaction was invoked exactly once
+                result.shouldBeLeft()
+                coVerify(exactly = 1) { transactional.inTransaction<DomainError, Unit>(any()) }
             }
         }
 

--- a/src/test/kotlin/io/sdkman/state/config/DefaultAppConfigUnitSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/config/DefaultAppConfigUnitSpec.kt
@@ -1,0 +1,44 @@
+package io.sdkman.state.config
+
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.server.config.MapApplicationConfig
+
+class DefaultAppConfigUnitSpec :
+    ShouldSpec({
+
+        should("apply default pool settings when database.pool.* keys are absent") {
+            val config =
+                DefaultAppConfig(
+                    MapApplicationConfig(
+                        "jwt.secret" to "any",
+                    ),
+                )
+
+            config.databasePoolMaxSize shouldBe 20
+            config.databasePoolMinIdle shouldBe 2
+            config.databasePoolConnectionTimeoutMs shouldBe 5_000L
+            config.databasePoolMaxLifetimeMs shouldBe 1_800_000L
+            config.databasePoolIdleTimeoutMs shouldBe 600_000L
+        }
+
+        should("override pool settings from supplied configuration") {
+            val config =
+                DefaultAppConfig(
+                    MapApplicationConfig(
+                        "database.pool.maxSize" to "50",
+                        "database.pool.minIdle" to "5",
+                        "database.pool.connectionTimeoutMs" to "10000",
+                        "database.pool.maxLifetimeMs" to "900000",
+                        "database.pool.idleTimeoutMs" to "120000",
+                        "jwt.secret" to "any",
+                    ),
+                )
+
+            config.databasePoolMaxSize shouldBe 50
+            config.databasePoolMinIdle shouldBe 5
+            config.databasePoolConnectionTimeoutMs shouldBe 10_000L
+            config.databasePoolMaxLifetimeMs shouldBe 900_000L
+            config.databasePoolIdleTimeoutMs shouldBe 120_000L
+        }
+    })

--- a/src/test/kotlin/io/sdkman/state/config/HikariPoolIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/config/HikariPoolIntegrationSpec.kt
@@ -1,0 +1,79 @@
+package io.sdkman.state.config
+
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.ktor.server.config.MapApplicationConfig
+import io.sdkman.state.adapter.secondary.persistence.VendorsTable
+import io.sdkman.state.adapter.secondary.persistence.dbQuery
+import io.sdkman.state.support.JwtTestSupport
+import io.sdkman.state.support.PostgresTestContainer
+import io.sdkman.state.support.sharedTestDatabase
+import io.sdkman.state.support.withCleanDatabase
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+
+@Tags("integration")
+class HikariPoolIntegrationSpec :
+    ShouldSpec({
+
+        afterSpec {
+            // Re-prime the shared default so subsequent specs use the working shared pool.
+            sharedTestDatabase
+        }
+
+        should("serve more concurrent dbQuery calls than maxSize as connections free up") {
+            withCleanDatabase {
+                val maxSize = 3
+                val concurrentQueries = 10
+                val holdMs = 50L
+
+                val config =
+                    DefaultAppConfig(
+                        MapApplicationConfig(
+                            "database.host" to PostgresTestContainer.host,
+                            "database.port" to PostgresTestContainer.port.toString(),
+                            "database.username" to PostgresTestContainer.username,
+                            "database.password" to PostgresTestContainer.password,
+                            "database.pool.maxSize" to maxSize.toString(),
+                            "database.pool.minIdle" to "0",
+                            "database.pool.connectionTimeoutMs" to "10000",
+                            "database.pool.maxLifetimeMs" to "60000",
+                            "database.pool.idleTimeoutMs" to "10000",
+                            "jwt.secret" to JwtTestSupport.TEST_SECRET,
+                        ),
+                    )
+
+                val dataSource = createHikariDataSource(config)
+                val database = Database.connect(dataSource)
+                try {
+                    val results =
+                        runBlocking {
+                            coroutineScope {
+                                (1..concurrentQueries)
+                                    .map {
+                                        async {
+                                            dbQuery {
+                                                delay(holdMs)
+                                                VendorsTable.selectAll().count()
+                                            }
+                                        }
+                                    }.awaitAll()
+                            }
+                        }
+
+                    results.size shouldBe concurrentQueries
+                    results.all { it == 0L } shouldBe true
+                } finally {
+                    TransactionManager.closeAndUnregister(database)
+                    dataSource.close()
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/io/sdkman/state/support/Application.kt
+++ b/src/test/kotlin/io/sdkman/state/support/Application.kt
@@ -16,8 +16,11 @@ import io.sdkman.state.application.service.TagServiceImpl
 import io.sdkman.state.application.service.VersionServiceImpl
 import io.sdkman.state.application.validation.VersionRequestValidator
 import io.sdkman.state.config.DefaultAppConfig
-import io.sdkman.state.config.configureDatabase
 import io.sdkman.state.config.configureJwtAuthentication
+import io.sdkman.state.config.createHikariDataSource
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.DatabaseConfig
+import java.sql.Connection
 
 fun testApplicationConfig(): MapApplicationConfig =
     MapApplicationConfig(
@@ -25,6 +28,11 @@ fun testApplicationConfig(): MapApplicationConfig =
         "database.port" to PostgresTestContainer.port.toString(),
         "database.username" to PostgresTestContainer.username,
         "database.password" to PostgresTestContainer.password,
+        "database.pool.maxSize" to "4",
+        "database.pool.minIdle" to "0",
+        "database.pool.connectionTimeoutMs" to "5000",
+        "database.pool.maxLifetimeMs" to "60000",
+        "database.pool.idleTimeoutMs" to "10000",
         "api.cache.control" to "600",
         "admin.email" to JwtTestSupport.ADMIN_EMAIL,
         "admin.password" to "testadminpassword",
@@ -33,17 +41,34 @@ fun testApplicationConfig(): MapApplicationConfig =
         "validation.semverish.candidates" to "java",
     )
 
+private val sharedTestAppConfig by lazy { DefaultAppConfig(testApplicationConfig()) }
+
+val sharedTestDataSource by lazy {
+    val dataSource = createHikariDataSource(sharedTestAppConfig)
+    Runtime.getRuntime().addShutdownHook(Thread { dataSource.close() })
+    dataSource
+}
+
+val sharedTestDatabase: Database by lazy {
+    Database.connect(
+        datasource = sharedTestDataSource,
+        databaseConfig =
+            DatabaseConfig {
+                defaultIsolationLevel = Connection.TRANSACTION_READ_COMMITTED
+            },
+    )
+}
+
 fun withTestApplication(fn: suspend (ApplicationTestBuilder.() -> Unit)) {
+    sharedTestDatabase
     testApplication {
         environment {
             config = testApplicationConfig()
         }
         application {
-            val appConfig = DefaultAppConfig(environment.config)
-            configureDatabase(appConfig)
             configureHTTP()
             configureSerialization()
-            configureJwtAuthentication(appConfig)
+            configureJwtAuthentication(sharedTestAppConfig)
 
             val versionsRepo = PostgresVersionRepository()
             val tagsRepo = PostgresTagRepository()
@@ -51,9 +76,9 @@ fun withTestApplication(fn: suspend (ApplicationTestBuilder.() -> Unit)) {
             val vendorRepo = PostgresVendorRepository()
             val tagService = TagServiceImpl(tagsRepo, auditRepo)
             val rateLimiter = RateLimiter()
-            val authService = AuthServiceImpl(vendorRepo, appConfig, rateLimiter)
+            val authService = AuthServiceImpl(vendorRepo, sharedTestAppConfig, rateLimiter)
 
-            val versionRequestValidator = VersionRequestValidator(appConfig.semverishCandidates)
+            val versionRequestValidator = VersionRequestValidator(sharedTestAppConfig.semverishCandidates)
 
             configureRouting(
                 versionService = VersionServiceImpl(versionsRepo, tagService, auditRepo),
@@ -61,7 +86,7 @@ fun withTestApplication(fn: suspend (ApplicationTestBuilder.() -> Unit)) {
                 healthRepo = PostgresHealthRepository(),
                 authService = authService,
                 vendorRepository = vendorRepo,
-                appConfig = appConfig,
+                appConfig = sharedTestAppConfig,
                 versionRequestValidator = versionRequestValidator,
             )
         }

--- a/src/test/kotlin/io/sdkman/state/support/Application.kt
+++ b/src/test/kotlin/io/sdkman/state/support/Application.kt
@@ -5,6 +5,7 @@ import io.ktor.server.testing.*
 import io.sdkman.state.adapter.primary.rest.configureHTTP
 import io.sdkman.state.adapter.primary.rest.configureRouting
 import io.sdkman.state.adapter.primary.rest.configureSerialization
+import io.sdkman.state.adapter.secondary.persistence.ExposedTransactional
 import io.sdkman.state.adapter.secondary.persistence.PostgresAuditRepository
 import io.sdkman.state.adapter.secondary.persistence.PostgresHealthRepository
 import io.sdkman.state.adapter.secondary.persistence.PostgresTagRepository
@@ -75,13 +76,14 @@ fun withTestApplication(fn: suspend (ApplicationTestBuilder.() -> Unit)) {
             val auditRepo = PostgresAuditRepository()
             val vendorRepo = PostgresVendorRepository()
             val tagService = TagServiceImpl(tagsRepo, auditRepo)
+            val transactional = ExposedTransactional()
             val rateLimiter = RateLimiter()
             val authService = AuthServiceImpl(vendorRepo, sharedTestAppConfig, rateLimiter)
 
             val versionRequestValidator = VersionRequestValidator(sharedTestAppConfig.semverishCandidates)
 
             configureRouting(
-                versionService = VersionServiceImpl(versionsRepo, tagService, auditRepo),
+                versionService = VersionServiceImpl(versionsRepo, tagService, auditRepo, transactional),
                 tagService = tagService,
                 healthRepo = PostgresHealthRepository(),
                 authService = authService,

--- a/src/test/kotlin/io/sdkman/state/support/Postgres.kt
+++ b/src/test/kotlin/io/sdkman/state/support/Postgres.kt
@@ -11,8 +11,6 @@ import io.sdkman.state.adapter.secondary.persistence.VendorsTable
 import io.sdkman.state.adapter.secondary.persistence.VersionTagsTable
 import io.sdkman.state.adapter.secondary.persistence.VersionsTable
 import io.sdkman.state.adapter.secondary.persistence.toDomain
-import io.sdkman.state.config.DefaultAppConfig
-import io.sdkman.state.config.jdbcUrl
 import io.sdkman.state.domain.model.AuditOperation
 import io.sdkman.state.domain.model.Distribution
 import io.sdkman.state.domain.model.Platform
@@ -162,25 +160,19 @@ fun selectLastUpdatedAt(
             }.firstOrNone()
     }
 
-private val testAppConfig by lazy { DefaultAppConfig(testApplicationConfig()) }
+private val migrationsApplied: Boolean by lazy {
+    Flyway
+        .configure()
+        .dataSource(sharedTestDataSource)
+        .load()
+        .migrate()
+    sharedTestDatabase
+    true
+}
 
-private fun initialisePostgres() =
-    Database
-        .connect(
-            url = testAppConfig.jdbcUrl,
-            user = DB_USERNAME,
-            password = DB_PASSWORD,
-            driver = "org.postgresql.Driver",
-        ).also {
-            Flyway
-                .configure()
-                .dataSource(
-                    testAppConfig.jdbcUrl,
-                    DB_USERNAME,
-                    DB_PASSWORD,
-                ).load()
-                .migrate()
-        }
+private fun initialisePostgres() {
+    migrationsApplied
+}
 
 fun selectAuditRecords(): List<VendorAuditRecord> =
     dbQuery {

--- a/src/test/kotlin/io/sdkman/state/support/Postgres.kt
+++ b/src/test/kotlin/io/sdkman/state/support/Postgres.kt
@@ -3,6 +3,8 @@ package io.sdkman.state.support
 import arrow.core.Option
 import arrow.core.firstOrNone
 import arrow.core.getOrElse
+import arrow.core.none
+import arrow.core.some
 import arrow.core.toOption
 import io.sdkman.state.adapter.secondary.persistence.AuditTable
 import io.sdkman.state.adapter.secondary.persistence.AuditVersionData
@@ -45,7 +47,7 @@ fun insertVersions(vararg cvs: Version) =
                 it[candidate] = cv.candidate
                 it[version] = cv.version
                 it[platform] = cv.platform.name
-                it[distribution] = cv.distribution.map { dist -> dist.name }.getOrNull()
+                it[distribution] = cv.distribution.map { dist -> dist.name }.getOrElse { NA_SENTINEL }
                 it[url] = cv.url
                 it[visible] = cv.visible.getOrElse { true }
                 it[md5sum] = cv.md5sum.getOrNull()
@@ -62,7 +64,7 @@ fun insertVersionWithId(cv: Version): Int =
                 it[candidate] = cv.candidate
                 it[version] = cv.version
                 it[platform] = cv.platform.name
-                it[distribution] = cv.distribution.map { dist -> dist.name }.getOrNull()
+                it[distribution] = cv.distribution.map { dist -> dist.name }.getOrElse { NA_SENTINEL }
                 it[url] = cv.url
                 it[visible] = cv.visible.getOrElse { true }
                 it[md5sum] = cv.md5sum.getOrNull()
@@ -123,13 +125,16 @@ fun selectVersion(
             .where {
                 (VersionsTable.candidate eq candidate) and
                     (VersionsTable.version eq version) and
-                    distribution.fold({ VersionsTable.distribution eq null }, { VersionsTable.distribution eq it.name }) and
+                    (VersionsTable.distribution eq distribution.map { it.name }.getOrElse { NA_SENTINEL }) and
                     (VersionsTable.platform eq platform.name)
             }.map {
                 Version(
                     candidate = it[VersionsTable.candidate],
                     version = it[VersionsTable.version],
-                    distribution = it[VersionsTable.distribution].toOption().map { dist -> Distribution.valueOf(dist) },
+                    distribution =
+                        it[VersionsTable.distribution].let { d ->
+                            if (d == NA_SENTINEL) none() else Distribution.valueOf(d).some()
+                        },
                     platform = Platform.valueOf(it[VersionsTable.platform]),
                     url = it[VersionsTable.url],
                     visible = it[VersionsTable.visible].toOption(),
@@ -152,7 +157,7 @@ fun selectLastUpdatedAt(
             .where {
                 (VersionsTable.candidate eq candidate) and
                     (VersionsTable.version eq version) and
-                    distribution.fold({ VersionsTable.distribution eq null }, { VersionsTable.distribution eq it.name }) and
+                    (VersionsTable.distribution eq distribution.map { it.name }.getOrElse { NA_SENTINEL }) and
                     (VersionsTable.platform eq platform.name)
             }.map {
                 val javaInstant = it[VersionsTable.lastUpdatedAt]


### PR DESCRIPTION
- docs: add concurrency optimisations spec
- chore: drop verbose pgjdbc loglevel from JDBC URL
- feat: introduce HikariCP connection pool
- docs: record explicit isolation level requirement in concurrency spec
- refactor: upsert versions to remove create-or-update race
- refactor: write version and tags in a single transaction
- refactor: collapse versions.distribution to NOT NULL with NA sentinel
- perf: collapse redundant queries in DELETE /versions
