### PR TITLE
feat(tags): add POST /versions/tags to assign a single tag to a version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ PROMPT_build.md
 ### Claude Code ###
 .claude/settings.local.json
 
+### Archon ###
+.archon/
+

--- a/specs/assign-tag-to-version.md
+++ b/specs/assign-tag-to-version.md
@@ -1,0 +1,206 @@
+# Assign Tag to Version
+
+There is currently no way to add a tag to an existing version without re-posting the entire version through `POST /versions`. That endpoint applies *replace* semantics to the tag set, so a client wanting to move or add a single tag must resend the full version payload and the complete desired tag list. This feature adds a dedicated, focused endpoint that assigns a single tag to an existing version, leaving the version's other tags untouched.
+
+It is the write-side counterpart to the existing tag resolution (`GET /versions/{candidate}/tags/{tag}`) and tag removal (`DELETE /versions/tags`) endpoints, completing the targeted tag lifecycle: assign, resolve, remove — none of which require touching the version payload.
+
+## Behaviour
+
+A client assigns a tag to a version by identifying the target version coordinates `(candidate, version, distribution, platform)` and the `tag` to apply. The tag is added to that version's existing tag set.
+
+Tags are mutually exclusive within a `(candidate, distribution, platform)` scope — a given tag points to exactly one version at a time. Assignment therefore behaves as "assert that this version holds this tag":
+
+- If the tag is not currently assigned anywhere in the scope, it is added to the target version.
+- If the tag currently points to a **different** version in the same scope, it is **moved** to the target version. This is identical to the move behaviour already exhibited by `POST /versions`.
+- If the tag already points to the target version, the operation is a **no-op** and still succeeds (idempotent).
+
+In all three cases the target version's *other* tags are preserved — this is an append/assign operation, never a replace.
+
+The endpoint manages tags only; it never creates a version. If the target version does not exist, the request fails with `404 Not Found`.
+
+This is an authenticated write endpoint. It uses the same authorization model as `POST /versions` and `DELETE /versions/tags`: a valid JWT is required; admin tokens bypass candidate checks; vendor tokens must be authorized for the request's `candidate`.
+
+## API Contract
+
+### Request
+
+```
+POST /versions/tags
+Authorization: Bearer <token>
+Content-Type: application/json
+```
+
+Request body (`TagAssignment`):
+
+| Field          | Required | Description                                          |
+|----------------|----------|------------------------------------------------------|
+| `candidate`    | yes      | The candidate name (e.g. `java`, `gradle`)           |
+| `version`      | yes      | The version string of the target version             |
+| `platform`     | yes      | Platform ID (must be a valid `Platform` enum value)  |
+| `distribution` | no       | Distribution (must be a valid `Distribution` if set) |
+| `tag`          | yes      | The tag to assign (e.g. `latest`, `lts`, `27`)       |
+
+```json
+{
+  "candidate": "java",
+  "version": "27.0.2",
+  "distribution": "TEMURIN",
+  "platform": "LINUX_X64",
+  "tag": "latest"
+}
+```
+
+### Response
+
+| Status                      | Body                       | When                                                        |
+|-----------------------------|----------------------------|-------------------------------------------------------------|
+| `204 No Content`            |                            | Tag assigned, moved, or already present (no-op)             |
+| `400 Bad Request`           | `ValidationErrorResponse`  | Validation failure or malformed JSON                        |
+| `401 Unauthorized`          |                            | Missing or invalid token                                    |
+| `403 Forbidden`             |                            | Vendor not authorized for the candidate                     |
+| `404 Not Found`             |                            | Target version does not exist for the given coordinates     |
+| `500 Internal Server Error` | `ErrorResponse`            | Database error                                              |
+
+Success returns no body — `204` is honest across all three success paths (new, moved, no-op), and consistent with every other write endpoint in the API.
+
+The `404` is returned with no body, mirroring the existing `DomainError.VersionNotFound → 404` mapping.
+
+## Business Rules
+
+1. **Single tag per request.** The endpoint assigns exactly one tag. There is no list form. Assigning multiple tags is multiple requests.
+2. **Append, not replace.** The target version's other tags are never removed. Only `POST /versions` applies replace semantics to a version's tag set.
+3. **A tag points to exactly one version.** Tags are unique within `(candidate, tag, distribution, platform)` scope. Assigning a tag that lives on another version in the same scope moves it; the source version keeps its remaining tags.
+4. **Idempotent.** Assigning a tag the version already holds succeeds with `204` and changes nothing.
+5. **The version must exist.** Assignment never creates a version. A non-existent target yields `404`; the version is identified by the exact `(candidate, version, distribution, platform)` tuple.
+6. **No semverish validation.** Unlike `POST /versions`, this endpoint does not apply semverish format validation to the `version` field. Semverish is a creation-time gate; a version that exists has already passed it, and a malformed/non-existent version simply falls through to `404`.
+7. **Distribution is optional.** Candidates without distributions (e.g. `gradle`, `scala`) assign tags without a distribution; candidates with distributions (e.g. `java`) require it to identify the correct scope — consistent with the rest of the API.
+8. **Tags are case-sensitive.** `latest` and `LATEST` are distinct. No normalisation is applied.
+
+## Validation
+
+Structural validation only, following the accumulated-error pattern used elsewhere (all failures returned in one `400` `ValidationErrorResponse`):
+
+- `candidate` must not be blank.
+- `version` must not be blank.
+- `platform` must be a valid `Platform` enum value.
+- `distribution`, if provided, must be a valid `Distribution` enum value.
+- `tag` must satisfy the existing tag rules: 1–50 characters, matching `^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,48}[a-zA-Z0-9])?$` (alphanumeric start and end; `.`, `-`, `_` permitted in the middle). The tag pattern is reused from the existing version-tag validation rather than redefined.
+
+## Auditing
+
+Tag assignment is recorded in the `vendor_audit` table, written **after** the transaction commits — an audit failure does not roll back the assignment, consistent with `POST /versions` and `DELETE /versions`.
+
+- A new `AuditOperation.TAG` value distinguishes tag assignment from version `CREATE`/`DELETE` in the audit trail.
+- The audit payload captures the assigned `tag` together with the target version coordinates `(candidate, version, distribution, platform)`.
+- "Moved from" provenance is **not** materialised into the record. It is reconstructable from history: the prior audit entry for the same tag scope identifies where the tag previously lived. This avoids an extra pre-write lookup and cross-layer plumbing for no information gain.
+
+## Domain & Implementation Notes
+
+- **DTO:** a new serializable `TagAssignment` request DTO with the five fields above (`distribution` as `Option`).
+- **Service / repository:** a new `assignTag(versionId, candidate, distribution, platform, tag)` on `TagService` / `TagRepository`. It performs the single race-safe `UPSERT` already used inside `replaceTags` — **without** the delete-not-in-list step. This naturally re-points the tag (move), is a no-op when already present (idempotent), and leaves sibling tags intact (append).
+- **Auditable:** a new `AuditOperation.TAG` enum value and a new `Auditable` subtype (e.g. `TagAssignment`) serialized into the existing `version_data` JSON column via a new branch in `toJsonElement()`.
+- **Transaction boundary:** the tag write runs inside the transaction; audit is recorded post-commit; a `DatabaseError` maps to `500`.
+- **No database migration required.** `version_tags` already exists, and the enriched audit detail rides in the existing `version_data` JSON column.
+
+## Access Matrix
+
+| Endpoint            | Anonymous | Vendor (own candidate) | Vendor (other candidate) | Admin |
+|---------------------|-----------|------------------------|--------------------------|-------|
+| `POST /versions/tags` | No (401)  | Yes                    | No (403)                 | Yes   |
+
+## Examples
+
+```gherkin
+Feature: Assign tag to version
+
+  Scenario: Assign a new tag to an existing version
+    Given a version "27.0.2" of "java" exists for "TEMURIN" on "LINUX_X64"
+      And the tag "latest" is not assigned in that scope
+    When an authorized client sends POST /versions/tags
+      | candidate | java     |
+      | version   | 27.0.2   |
+      | distribution | TEMURIN |
+      | platform  | LINUX_X64 |
+      | tag       | latest   |
+    Then the response status is 204
+      And version "27.0.2" carries the tag "latest"
+
+  Scenario: Assigning a tag moves it from another version
+    Given version "27.0.1" of "java" for "TEMURIN" on "LINUX_X64" is tagged "latest"
+      And version "27.0.2" of "java" for "TEMURIN" on "LINUX_X64" exists
+    When an authorized client assigns "latest" to "27.0.2"
+    Then the response status is 204
+      And version "27.0.2" carries the tag "latest"
+      And version "27.0.1" no longer carries the tag "latest"
+
+  Scenario: Moving a tag preserves the source version's other tags
+    Given version "27.0.1" of "java" for "TEMURIN" on "LINUX_X64" is tagged "latest" and "27"
+      And version "27.0.2" of "java" for "TEMURIN" on "LINUX_X64" exists
+    When an authorized client assigns "latest" to "27.0.2"
+    Then version "27.0.1" still carries the tag "27"
+
+  Scenario: Assigning a tag preserves the target version's existing tags
+    Given version "27.0.2" of "java" for "TEMURIN" on "LINUX_X64" is tagged "27"
+    When an authorized client assigns "latest" to "27.0.2"
+    Then version "27.0.2" carries both "27" and "latest"
+
+  Scenario: Re-assigning a tag the version already has is a no-op
+    Given version "27.0.2" of "java" for "TEMURIN" on "LINUX_X64" is tagged "latest"
+    When an authorized client assigns "latest" to "27.0.2"
+    Then the response status is 204
+      And version "27.0.2" still carries exactly its existing tags
+
+  Scenario: Assign a tag for a candidate without distribution
+    Given a version "8.12" of "gradle" exists on "UNIVERSAL"
+    When an authorized client sends POST /versions/tags
+      | candidate | gradle    |
+      | version   | 8.12      |
+      | platform  | UNIVERSAL |
+      | tag       | latest    |
+    Then the response status is 204
+
+  Scenario: Target version does not exist
+    Given no version "99.0.0" of "java" exists for "TEMURIN" on "LINUX_X64"
+    When an authorized client assigns "latest" to that version
+    Then the response status is 404
+
+  Scenario: Invalid tag format
+    Given a version "27.0.2" of "java" exists for "TEMURIN" on "LINUX_X64"
+    When an authorized client assigns the tag "-bad-" to it
+    Then the response status is 400
+
+  Scenario: Unauthenticated request
+    When an unauthenticated client sends POST /versions/tags
+    Then the response status is 401
+
+  Scenario: Vendor not authorized for the candidate
+    Given a vendor token authorized only for "scala"
+    When the vendor assigns a tag to a "java" version
+    Then the response status is 403
+```
+
+## Out of Scope
+
+- No changes to `POST /versions` and its replace semantics for the full tag set.
+- No changes to `DELETE /versions/tags` or `GET /versions/{candidate}/tags/{tag}`.
+- No multi-tag (list) assignment form.
+- No materialised "moved from" provenance in the audit record (reconstructable from history).
+- No database migration.
+
+## Acceptance Criteria
+
+- [ ] `POST /versions/tags` assigns a tag to an existing version and returns `204`
+- [ ] Assigning a tag that lives on another version moves it; the source version keeps its other tags
+- [ ] Assigning a tag preserves the target version's existing tags (append, not replace)
+- [ ] Re-assigning a tag the version already has returns `204` and changes nothing
+- [ ] Works for candidates without distributions
+- [ ] Returns `404` (no body) when the target version does not exist
+- [ ] Returns `400` with accumulated validation failures for blank fields, invalid enums, or invalid tag format
+- [ ] Returns `401` for unauthenticated requests and `403` for vendors not authorized for the candidate
+- [ ] Returns `500` on database error
+- [ ] No semverish validation is applied to the `version` field
+- [ ] Tag assignment is recorded under `AuditOperation.TAG` with tag + version coordinates; audit failure does not roll back the assignment
+- [ ] OpenAPI documentation updated with the new endpoint and `TagAssignment` schema
+- [ ] No nullable types used — follows the Arrow `Option` pattern
+- [ ] All quality gates pass (`./gradlew check`)
+```

--- a/src/main/kotlin/io/sdkman/state/Application.kt
+++ b/src/main/kotlin/io/sdkman/state/Application.kt
@@ -37,7 +37,7 @@ fun Application.module() {
     val tagsRepo = PostgresTagRepository()
     val auditRepo = PostgresAuditRepository()
     val vendorRepo = PostgresVendorRepository()
-    val tagService = TagServiceImpl(tagsRepo, auditRepo)
+    val tagService = TagServiceImpl(tagsRepo, auditRepo, versionsRepo)
     val transactional = ExposedTransactional()
     val rateLimiter = RateLimiter()
     launch {

--- a/src/main/kotlin/io/sdkman/state/adapter/primary/rest/TagRoutes.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/primary/rest/TagRoutes.kt
@@ -9,14 +9,59 @@ import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import io.sdkman.state.adapter.primary.rest.dto.ErrorResponse
+import io.sdkman.state.adapter.primary.rest.dto.TagAssignmentDto
 import io.sdkman.state.adapter.primary.rest.dto.UniqueTagDto
 import io.sdkman.state.adapter.primary.rest.dto.toDomain
+import io.sdkman.state.application.validation.TagAssignmentValidator
 import io.sdkman.state.application.validation.UniqueTagValidator
 import io.sdkman.state.domain.error.DomainError
 import io.sdkman.state.domain.error.FieldError
 import io.sdkman.state.domain.service.TagService
 
 fun Route.tagRoutes(tagService: TagService) {
+    assignTagRoute(tagService)
+    deleteTagRoute(tagService)
+}
+
+private fun Route.assignTagRoute(tagService: TagService) {
+    post("/versions/tags") {
+        call.response.header(HttpHeaders.CacheControl, "no-store")
+        val vendorId = call.authenticatedVendorId()
+        val email = call.authenticatedEmail()
+        val role = call.authenticatedRole()
+        val candidates = call.authenticatedCandidates()
+        either<DomainError, Unit> {
+            val assignment =
+                Either
+                    .catch { call.receive<TagAssignmentDto>() }
+                    .map { it.toDomain() }
+                    .mapLeft {
+                        DomainError.ValidationFailed(
+                            "Invalid request: ${it.message.toOption().getOrElse { "Unknown error" }}",
+                        )
+                    }.bind()
+            TagAssignmentValidator
+                .validate(assignment)
+                .mapLeft { errors ->
+                    DomainError.ValidationFailures(errors.map { FieldError(it.field, it.message) })
+                }.bind()
+            // Admin tokens bypass candidate authorization — admin can operate on any candidate
+            if (role == "vendor" && assignment.candidate !in candidates) {
+                call.respond(
+                    HttpStatusCode.Forbidden,
+                    ErrorResponse("Forbidden", "Not authorized for candidate: ${assignment.candidate}"),
+                )
+                return@post
+            }
+            tagService.assignTag(assignment, vendorId, email).bind()
+        }.fold(
+            ifLeft = { error -> call.respondDomainError(error) },
+            ifRight = { call.respond(HttpStatusCode.NoContent) },
+        )
+    }
+}
+
+private fun Route.deleteTagRoute(tagService: TagService) {
     delete("/versions/tags") {
         call.response.header(HttpHeaders.CacheControl, "no-store")
         val vendorId = call.authenticatedVendorId()

--- a/src/main/kotlin/io/sdkman/state/adapter/primary/rest/dto/TagAssignmentDto.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/primary/rest/dto/TagAssignmentDto.kt
@@ -1,0 +1,30 @@
+@file:UseSerializers(OptionSerializer::class)
+
+package io.sdkman.state.adapter.primary.rest.dto
+
+import arrow.core.Option
+import arrow.core.none
+import arrow.core.serialization.OptionSerializer
+import io.sdkman.state.domain.model.Distribution
+import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.TagAssignment
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+
+@Serializable
+data class TagAssignmentDto(
+    val candidate: String,
+    val version: String,
+    val platform: Platform,
+    val distribution: Option<Distribution> = none(),
+    val tag: String,
+)
+
+fun TagAssignmentDto.toDomain(): TagAssignment =
+    TagAssignment(
+        candidate = candidate,
+        version = version,
+        distribution = distribution,
+        platform = platform,
+        tag = tag,
+    )

--- a/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/AuditSerialization.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/AuditSerialization.kt
@@ -7,6 +7,7 @@ import arrow.core.none
 import arrow.core.serialization.OptionSerializer
 import io.sdkman.state.domain.model.Distribution
 import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.TagAssignment
 import io.sdkman.state.domain.model.UniqueTag
 import io.sdkman.state.domain.model.Version
 import kotlinx.serialization.Serializable
@@ -34,6 +35,15 @@ internal data class AuditTagData(
     val platform: Platform,
 )
 
+@Serializable
+internal data class AuditTagAssignmentData(
+    val candidate: String,
+    val version: String,
+    val tag: String,
+    val distribution: Option<Distribution> = none(),
+    val platform: Platform,
+)
+
 internal fun Version.toAuditData(): AuditVersionData =
     AuditVersionData(
         candidate = candidate,
@@ -51,6 +61,15 @@ internal fun Version.toAuditData(): AuditVersionData =
 internal fun UniqueTag.toAuditData(): AuditTagData =
     AuditTagData(
         candidate = candidate,
+        tag = tag,
+        distribution = distribution,
+        platform = platform,
+    )
+
+internal fun TagAssignment.toAuditData(): AuditTagAssignmentData =
+    AuditTagAssignmentData(
+        candidate = candidate,
+        version = version,
         tag = tag,
         distribution = distribution,
         platform = platform,

--- a/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresAuditRepository.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresAuditRepository.kt
@@ -4,6 +4,7 @@ import arrow.core.Either
 import io.sdkman.state.domain.error.DatabaseFailure
 import io.sdkman.state.domain.model.AuditOperation
 import io.sdkman.state.domain.model.Auditable
+import io.sdkman.state.domain.model.TagAssignment
 import io.sdkman.state.domain.model.UniqueTag
 import io.sdkman.state.domain.model.Version
 import io.sdkman.state.domain.repository.AuditRepository
@@ -34,6 +35,7 @@ class PostgresAuditRepository : AuditRepository {
         when (this) {
             is Version -> Json.encodeToJsonElement(this.toAuditData())
             is UniqueTag -> Json.encodeToJsonElement(this.toAuditData())
+            is TagAssignment -> Json.encodeToJsonElement(this.toAuditData())
         }
 
     override suspend fun recordAudit(

--- a/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepository.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepository.kt
@@ -163,13 +163,54 @@ class PostgresTagRepository : TagRepository {
                 )
             }
 
+    // Assigns a single tag to a version via the same race-safe UPSERT used inside replaceTags,
+    // but without the delete-not-in-list step. This re-points the row's `version_id` when the tag
+    // is being moved from another version in scope (mutual exclusivity), is a no-op on same-payload
+    // re-assignment (idempotent), and leaves the version's other tags untouched (append, not replace).
     override suspend fun assignTag(
         versionId: Int,
         candidate: String,
         distribution: Option<Distribution>,
         platform: Platform,
         tag: String,
-    ): Either<DatabaseFailure, Unit> = TODO("Implemented in the next plan item")
+    ): Either<DatabaseFailure, Unit> =
+        Either
+            .catch {
+                dbQuery {
+                    val distDb = distribution.map { it.name }.getOrNull()
+                    val platformDb = platform.name
+
+                    VersionTagsTable.upsert(
+                        VersionTagsTable.candidate,
+                        VersionTagsTable.tag,
+                        VersionTagsTable.distribution,
+                        VersionTagsTable.platform,
+                        onUpdateExclude =
+                            listOf(
+                                VersionTagsTable.id,
+                                VersionTagsTable.candidate,
+                                VersionTagsTable.tag,
+                                VersionTagsTable.distribution,
+                                VersionTagsTable.platform,
+                                VersionTagsTable.createdAt,
+                            ),
+                    ) {
+                        it[this.candidate] = candidate
+                        it[this.tag] = tag
+                        it[this.distribution] = distDb
+                        it[this.platform] = platformDb
+                        it[this.versionId] = versionId
+                        it[this.createdAt] = Instant.now()
+                        it[this.lastUpdatedAt] = Instant.now()
+                    }
+                    Unit
+                }
+            }.mapLeft { error ->
+                DatabaseFailure.QueryExecutionFailure(
+                    message = "Failed to assign tag: ${error.message}",
+                    cause = error,
+                )
+            }
 
     override suspend fun deleteTag(uniqueTag: UniqueTag): Either<DatabaseFailure, Int> =
         Either

--- a/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepository.kt
+++ b/src/main/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepository.kt
@@ -163,6 +163,14 @@ class PostgresTagRepository : TagRepository {
                 )
             }
 
+    override suspend fun assignTag(
+        versionId: Int,
+        candidate: String,
+        distribution: Option<Distribution>,
+        platform: Platform,
+        tag: String,
+    ): Either<DatabaseFailure, Unit> = TODO("Implemented in the next plan item")
+
     override suspend fun deleteTag(uniqueTag: UniqueTag): Either<DatabaseFailure, Int> =
         Either
             .catch {

--- a/src/main/kotlin/io/sdkman/state/application/service/TagServiceImpl.kt
+++ b/src/main/kotlin/io/sdkman/state/application/service/TagServiceImpl.kt
@@ -2,14 +2,18 @@ package io.sdkman.state.application.service
 
 import arrow.core.Either
 import arrow.core.Option
+import arrow.core.getOrElse
 import arrow.core.raise.either
 import io.sdkman.state.domain.error.DomainError
 import io.sdkman.state.domain.model.AuditOperation
 import io.sdkman.state.domain.model.Distribution
 import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.TagAssignment
 import io.sdkman.state.domain.model.UniqueTag
+import io.sdkman.state.domain.model.UniqueVersion
 import io.sdkman.state.domain.repository.AuditRepository
 import io.sdkman.state.domain.repository.TagRepository
+import io.sdkman.state.domain.repository.VersionRepository
 import io.sdkman.state.domain.service.TagService
 import org.slf4j.LoggerFactory
 import java.util.UUID
@@ -17,6 +21,7 @@ import java.util.UUID
 class TagServiceImpl(
     private val tagsRepo: TagRepository,
     private val auditRepo: AuditRepository,
+    private val versionsRepo: VersionRepository,
 ) : TagService {
     private val logger = LoggerFactory.getLogger(TagServiceImpl::class.java)
 
@@ -52,6 +57,35 @@ class TagServiceImpl(
                 .recordAudit(vendorId, email, AuditOperation.DELETE, uniqueTag)
                 .onLeft { error ->
                     logger.warn("Audit logging failed for tag deletion: ${error.message}")
+                }
+        }
+
+    override suspend fun assignTag(
+        assignment: TagAssignment,
+        vendorId: UUID,
+        email: String,
+    ): Either<DomainError, Unit> =
+        either {
+            val versionId =
+                versionsRepo
+                    .findVersionId(
+                        UniqueVersion(
+                            candidate = assignment.candidate,
+                            version = assignment.version,
+                            distribution = assignment.distribution,
+                            platform = assignment.platform,
+                        ),
+                    ).mapLeft { DomainError.DatabaseError(it) }
+                    .bind()
+                    .getOrElse { raise(DomainError.VersionNotFound(assignment.candidate, assignment.version)) }
+            tagsRepo
+                .assignTag(versionId, assignment.candidate, assignment.distribution, assignment.platform, assignment.tag)
+                .mapLeft { DomainError.DatabaseError(it) }
+                .bind()
+            auditRepo
+                .recordAudit(vendorId, email, AuditOperation.TAG, assignment)
+                .onLeft { error ->
+                    logger.warn("Audit logging failed for tag assignment: ${error.message}")
                 }
         }
 }

--- a/src/main/kotlin/io/sdkman/state/application/validation/TagAssignmentValidator.kt
+++ b/src/main/kotlin/io/sdkman/state/application/validation/TagAssignmentValidator.kt
@@ -1,0 +1,31 @@
+package io.sdkman.state.application.validation
+
+import arrow.core.Either
+import arrow.core.NonEmptyList
+import arrow.core.left
+import arrow.core.right
+import arrow.core.toNonEmptyListOrNone
+import io.sdkman.state.domain.model.TagAssignment
+
+// Structural validation for a single tag assignment, following the accumulated-error
+// pattern used by `UniqueTagValidator`: all failures are returned together in one
+// `NonEmptyList`. This validator does strictly more than `UniqueTagValidator` — it
+// also requires a non-blank `version` and validates the `tag` against the shared
+// `TagNameRules`. Platform/distribution enum validity is enforced earlier, at DTO
+// deserialization, so it is not re-checked here.
+object TagAssignmentValidator {
+    fun validate(assignment: TagAssignment): Either<NonEmptyList<ValidationError>, TagAssignment> {
+        val errors =
+            buildList {
+                if (assignment.candidate.isBlank()) add(EmptyFieldError("candidate"))
+                if (assignment.version.isBlank()) add(EmptyFieldError("version"))
+                addAll(TagNameRules.validate("tag", assignment.tag))
+            }
+        return errors
+            .toNonEmptyListOrNone()
+            .fold(
+                { assignment.right() },
+                { nel -> nel.left() },
+            )
+    }
+}

--- a/src/main/kotlin/io/sdkman/state/application/validation/TagNameRules.kt
+++ b/src/main/kotlin/io/sdkman/state/application/validation/TagNameRules.kt
@@ -1,0 +1,34 @@
+package io.sdkman.state.application.validation
+
+// Shared tag-name validation rules. A tag must be 1–50 characters, start and end
+// with an alphanumeric character, and use only alphanumerics, dots, hyphens, and
+// underscores in between. Both `VersionRequestValidator` (tag list on a version)
+// and `TagAssignmentValidator` (single tag assignment) reuse this single rule so
+// the pattern and length bound are defined exactly once.
+object TagNameRules {
+    const val MAX_LENGTH = 50
+    val PATTERN = Regex("^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,48}[a-zA-Z0-9])?$")
+
+    fun validate(
+        field: String,
+        tag: String,
+    ): List<ValidationError> =
+        when {
+            tag.isBlank() ->
+                listOf(InvalidTagError(field, "Tag must not be blank"))
+
+            tag.length > MAX_LENGTH ->
+                listOf(InvalidTagError(field, "Tag must not exceed $MAX_LENGTH characters"))
+
+            !PATTERN.matches(tag) ->
+                listOf(
+                    InvalidTagError(
+                        field,
+                        "Tag must contain only alphanumeric characters, dots, hyphens, and underscores, " +
+                            "and must start and end with an alphanumeric character",
+                    ),
+                )
+
+            else -> emptyList()
+        }
+}

--- a/src/main/kotlin/io/sdkman/state/application/validation/VersionRequestValidator.kt
+++ b/src/main/kotlin/io/sdkman/state/application/validation/VersionRequestValidator.kt
@@ -26,7 +26,6 @@ class VersionRequestValidator(
         private val HEX_PATTERN_32 = Regex("^[0-9a-fA-F]{32}$")
         private val HEX_PATTERN_64 = Regex("^[0-9a-fA-F]{64}$")
         private val HEX_PATTERN_128 = Regex("^[0-9a-fA-F]{128}$")
-        private val TAG_NAME_PATTERN = Regex("^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,48}[a-zA-Z0-9])?$")
         private val json = Json { explicitNulls = false }
     }
 
@@ -214,25 +213,7 @@ class VersionRequestValidator(
     private fun validateTag(
         index: Int,
         tag: String,
-    ): List<ValidationError> =
-        when {
-            tag.isBlank() ->
-                listOf(InvalidTagError("tags[$index]", "Tag must not be blank"))
-
-            tag.length > 50 ->
-                listOf(InvalidTagError("tags[$index]", "Tag must not exceed 50 characters"))
-
-            !TAG_NAME_PATTERN.matches(tag) ->
-                listOf(
-                    InvalidTagError(
-                        "tags[$index]",
-                        "Tag must contain only alphanumeric characters, dots, hyphens, and underscores, " +
-                            "and must start and end with an alphanumeric character",
-                    ),
-                )
-
-            else -> emptyList()
-        }
+    ): List<ValidationError> = TagNameRules.validate("tags[$index]", tag)
 
     // Returns Right(Unit) when upstream validation already failed, to avoid
     // double-reporting errors that are already in the accumulated error list.

--- a/src/main/kotlin/io/sdkman/state/domain/model/Audit.kt
+++ b/src/main/kotlin/io/sdkman/state/domain/model/Audit.kt
@@ -5,4 +5,5 @@ sealed interface Auditable
 enum class AuditOperation {
     CREATE,
     DELETE,
+    TAG,
 }

--- a/src/main/kotlin/io/sdkman/state/domain/model/TagAssignment.kt
+++ b/src/main/kotlin/io/sdkman/state/domain/model/TagAssignment.kt
@@ -1,0 +1,12 @@
+package io.sdkman.state.domain.model
+
+import arrow.core.Option
+import arrow.core.none
+
+data class TagAssignment(
+    val candidate: String,
+    val version: String,
+    val distribution: Option<Distribution> = none(),
+    val platform: Platform,
+    val tag: String,
+) : Auditable

--- a/src/main/kotlin/io/sdkman/state/domain/repository/TagRepository.kt
+++ b/src/main/kotlin/io/sdkman/state/domain/repository/TagRepository.kt
@@ -23,6 +23,14 @@ interface TagRepository {
         tags: List<String>,
     ): Either<DatabaseFailure, Unit>
 
+    suspend fun assignTag(
+        versionId: Int,
+        candidate: String,
+        distribution: Option<Distribution>,
+        platform: Platform,
+        tag: String,
+    ): Either<DatabaseFailure, Unit>
+
     suspend fun deleteTag(uniqueTag: UniqueTag): Either<DatabaseFailure, Int>
 
     suspend fun hasTagsForVersion(versionId: Int): Either<DatabaseFailure, Boolean>

--- a/src/main/kotlin/io/sdkman/state/domain/service/TagService.kt
+++ b/src/main/kotlin/io/sdkman/state/domain/service/TagService.kt
@@ -5,6 +5,7 @@ import arrow.core.Option
 import io.sdkman.state.domain.error.DomainError
 import io.sdkman.state.domain.model.Distribution
 import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.TagAssignment
 import io.sdkman.state.domain.model.UniqueTag
 import java.util.UUID
 
@@ -21,6 +22,12 @@ interface TagService {
 
     suspend fun deleteTag(
         uniqueTag: UniqueTag,
+        vendorId: UUID,
+        email: String,
+    ): Either<DomainError, Unit>
+
+    suspend fun assignTag(
+        assignment: TagAssignment,
         vendorId: UUID,
         email: String,
     ): Either<DomainError, Unit>

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -205,6 +205,75 @@ paths:
                   value:
                     error: "Not Found"
                     message: "Tag 'nonexistent' not found"
+    post:
+      description: "Assign a single tag to an existing version (append, not replace). The tag is added to the target version's existing tag set; a tag held by another version in the same (candidate, distribution, platform) scope is moved; re-assigning a tag the version already holds is an idempotent no-op. Never creates a version. No semverish validation is applied to the version field."
+      security:
+        - bearerAuth: []
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: "#/components/schemas/TagAssignment"
+            examples:
+              with_distribution:
+                summary: "Assign a tag with distribution"
+                value:
+                  candidate: "java"
+                  version: "27.0.2"
+                  distribution: "TEMURIN"
+                  platform: "LINUX_X64"
+                  tag: "latest"
+              without_distribution:
+                summary: "Assign a tag without distribution"
+                value:
+                  candidate: "gradle"
+                  version: "8.12"
+                  platform: "UNIVERSAL"
+                  tag: "latest"
+        required: true
+      responses:
+        "204":
+          description: "No Content - Tag assigned, moved, or already present (no-op)"
+        "400":
+          description: "Bad Request - Validation errors or malformed JSON"
+          content:
+            'application/json':
+              schema:
+                $ref: "#/components/schemas/ValidationErrorResponse"
+              examples:
+                validation_error:
+                  summary: "Accumulated validation failures"
+                  value:
+                    error: "Validation Error"
+                    failures:
+                      - field: "candidate"
+                        message: "Candidate must not be blank"
+                      - field: "version"
+                        message: "Version must not be blank"
+                      - field: "tag"
+                        message: "Tag must match the pattern ^[a-zA-Z0-9]([a-zA-Z0-9._-]{0,48}[a-zA-Z0-9])?$"
+        "401":
+          description: "Unauthorized - Missing or invalid authentication"
+        "403":
+          description: "Forbidden - Vendor not authorized for this candidate"
+          content:
+            'application/json':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+        "404":
+          description: "Not Found - Target version does not exist for the given coordinates"
+        "500":
+          description: "Internal Server Error - Database error"
+          content:
+            'application/json':
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+              examples:
+                database_error:
+                  summary: "Database error"
+                  value:
+                    error: "Database error"
+                    message: "null"
   /login:
     post:
       description: "Authenticate and obtain a JWT token"
@@ -661,6 +730,51 @@ components:
         - "candidate"
         - "tag"
         - "platform"
+    TagAssignment:
+      type: "object"
+      properties:
+        candidate:
+          type: "string"
+        version:
+          type: "string"
+        distribution:
+          type: "string"
+          enum:
+            - "BISHENG"
+            - "CORRETTO"
+            - "GRAALCE"
+            - "GRAALVM"
+            - "JETBRAINS"
+            - "KONA"
+            - "LIBERICA"
+            - "LIBERICA_NIK"
+            - "MANDREL"
+            - "MICROSOFT"
+            - "OPENJDK"
+            - "ORACLE"
+            - "SAP_MACHINE"
+            - "SEMERU"
+            - "TEMURIN"
+            - "ZULU"
+        platform:
+          type: "string"
+          enum:
+            - "LINUX_X32"
+            - "LINUX_X64"
+            - "LINUX_ARM32HF"
+            - "LINUX_ARM32SF"
+            - "LINUX_ARM64"
+            - "MAC_X64"
+            - "MAC_ARM64"
+            - "WINDOWS_X64"
+            - "UNIVERSAL"
+        tag:
+          type: "string"
+      required:
+        - "candidate"
+        - "version"
+        - "platform"
+        - "tag"
     ValidationErrorResponse:
       type: "object"
       properties:

--- a/src/test/kotlin/io/sdkman/state/acceptance/HealthCheckAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/HealthCheckAcceptanceSpec.kt
@@ -92,7 +92,7 @@ class HealthCheckAcceptanceSpec :
                         val tagsRepo = PostgresTagRepository()
                         val auditRepo = PostgresAuditRepository()
                         val vendorRepo = PostgresVendorRepository()
-                        val tagService = TagServiceImpl(tagsRepo, auditRepo)
+                        val tagService = TagServiceImpl(tagsRepo, auditRepo, versionsRepo)
                         val transactional = ExposedTransactional()
                         val rateLimiter = RateLimiter()
                         val authService = AuthServiceImpl(vendorRepo, appConfig, rateLimiter)

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -440,4 +440,28 @@ class PostVersionTagAssignmentAcceptanceSpec :
                 }
             }
         }
+
+        should("return 401 Unauthorized when assigning a tag without authentication") {
+            withCleanDatabase {
+                // when: posting a well-formed assignment with no bearer token
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = "java",
+                                    version = "27.0.2",
+                                    distribution = Distribution.TEMURIN.some(),
+                                    platform = Platform.LINUX_X64,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                        }
+
+                    // then: 401 — authentication is required before any processing
+                    response.status shouldBe HttpStatusCode.Unauthorized
+                }
+            }
+        }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -173,4 +173,51 @@ class PostVersionTagAssignmentAcceptanceSpec :
                 selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("27", "latest")
             }
         }
+
+        should("be an idempotent 204 no-op when re-assigning a tag the version already holds") {
+            val candidate = "java"
+            val version = "27.0.2"
+            val distribution = Distribution.TEMURIN
+            val platform = Platform.LINUX_X64
+
+            withCleanDatabase {
+                // given: a version already tagged "latest"
+                val versionId =
+                    insertVersionWithId(
+                        Version(
+                            candidate = candidate,
+                            version = version,
+                            platform = platform,
+                            url = "https://java-27.0.2-tem",
+                            visible = true.some(),
+                            distribution = distribution.some(),
+                        ),
+                    )
+                insertTag(candidate, "latest", distribution.some(), platform, versionId)
+
+                // when: re-assigning the tag it already holds
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = candidate,
+                                    version = version,
+                                    distribution = distribution.some(),
+                                    platform = platform,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 204 No Content (idempotent success)
+                    response.status shouldBe HttpStatusCode.NoContent
+                }
+
+                // and: the tag set is unchanged
+                selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("latest")
+            }
+        }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.ktor.client.request.*
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.statement.*
@@ -301,6 +302,52 @@ class PostVersionTagAssignmentAcceptanceSpec :
 
                 // and: no version was created for the requested coordinates
                 selectVersion(candidate, version, distribution.some(), platform) shouldBe none()
+            }
+        }
+
+        should("return 400 Bad Request when the tag format is invalid") {
+            val candidate = "java"
+            val version = "27.0.2"
+            val distribution = Distribution.TEMURIN
+            val platform = Platform.LINUX_X64
+
+            withCleanDatabase {
+                // given: the target version exists, so only the tag format is at fault
+                insertVersionWithId(
+                    Version(
+                        candidate = candidate,
+                        version = version,
+                        platform = platform,
+                        url = "https://java-27.0.2-tem",
+                        visible = true.some(),
+                        distribution = distribution.some(),
+                    ),
+                )
+
+                // when: assigning a tag whose format breaks the tag rules
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = candidate,
+                                    version = version,
+                                    distribution = distribution.some(),
+                                    platform = platform,
+                                    tag = "-bad-",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 400 Bad Request naming the offending field and rule
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    val body = response.bodyAsText()
+                    body shouldContain "Validation Error"
+                    body shouldContain "tag"
+                    body shouldContain "must start and end with an alphanumeric character"
+                }
             }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -380,4 +380,34 @@ class PostVersionTagAssignmentAcceptanceSpec :
                 }
             }
         }
+
+        should("return 400 Bad Request when the platform is not a valid enum value") {
+            // a raw body is needed: the typed DTO cannot represent an invalid Platform
+            val requestBody =
+                """
+                {
+                    "candidate": "java",
+                    "version": "27.0.2",
+                    "distribution": "TEMURIN",
+                    "platform": "NOT_A_PLATFORM",
+                    "tag": "latest"
+                }
+                """.trimIndent()
+
+            withCleanDatabase {
+                // when: posting an assignment with an unknown platform
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(requestBody)
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 400 — the bad enum is rejected at deserialization
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    response.bodyAsText() shouldContain "Invalid request"
+                }
+            }
+        }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -10,6 +10,7 @@ import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.*
 import io.ktor.client.request.bearerAuth
+import io.ktor.client.statement.*
 import io.ktor.http.*
 import io.sdkman.state.domain.model.Distribution
 import io.sdkman.state.domain.model.Platform
@@ -264,6 +265,42 @@ class PostVersionTagAssignmentAcceptanceSpec :
 
                 // and: the version carries the assigned tag within the NULL-distribution scope
                 selectTagNames(versionId) shouldContain "latest"
+            }
+        }
+
+        should("return 404 Not Found with an empty body when the target version does not exist") {
+            val candidate = "java"
+            val version = "99.0.0"
+            val distribution = Distribution.TEMURIN
+            val platform = Platform.LINUX_X64
+
+            withCleanDatabase {
+                // given: no version exists for the requested coordinates
+
+                // when: assigning a tag to a non-existent version
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = candidate,
+                                    version = version,
+                                    distribution = distribution.some(),
+                                    platform = platform,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 404 Not Found with no body
+                    response.status shouldBe HttpStatusCode.NotFound
+                    response.bodyAsText() shouldBe ""
+                }
+
+                // and: no version was created for the requested coordinates
+                selectVersion(candidate, version, distribution.some(), platform) shouldBe none()
             }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -6,6 +6,7 @@ import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -13,12 +14,16 @@ import io.ktor.client.request.*
 import io.ktor.client.request.bearerAuth
 import io.ktor.client.statement.*
 import io.ktor.http.*
+import io.sdkman.state.domain.model.AuditOperation
 import io.sdkman.state.domain.model.Distribution
 import io.sdkman.state.domain.model.Platform
 import io.sdkman.state.domain.model.TagAssignment
 import io.sdkman.state.domain.model.Version
 import io.sdkman.state.support.*
 import io.sdkman.state.support.JwtTestSupport
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
 
 @Tags("acceptance")
 class PostVersionTagAssignmentAcceptanceSpec :
@@ -488,6 +493,61 @@ class PostVersionTagAssignmentAcceptanceSpec :
                     // then: 403 — the candidate check rejects before any version lookup
                     response.status shouldBe HttpStatusCode.Forbidden
                 }
+            }
+        }
+
+        should("record an audit entry under AuditOperation.TAG with the tag and version coordinates") {
+            val candidate = "java"
+            val version = "27.0.2"
+            val distribution = Distribution.TEMURIN
+            val platform = Platform.LINUX_X64
+
+            withCleanDatabase {
+                // given: a version with no tags
+                insertVersionWithId(
+                    Version(
+                        candidate = candidate,
+                        version = version,
+                        platform = platform,
+                        url = "https://java-27.0.2-tem",
+                        visible = true.some(),
+                        distribution = distribution.some(),
+                    ),
+                )
+
+                // when: assigning a tag to the version
+                withTestApplication {
+                    client
+                        .post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = candidate,
+                                    version = version,
+                                    distribution = distribution.some(),
+                                    platform = platform,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }.status shouldBe HttpStatusCode.NoContent
+                }
+
+                // then: a TAG audit record captures the acting vendor and the assignment payload
+                val auditRecords = selectAuditRecordsByOperation(AuditOperation.TAG)
+                auditRecords shouldHaveSize 1
+                val record = auditRecords.first()
+                record.vendorId shouldBe JwtTestSupport.NIL_UUID
+                record.email shouldBe "admin@sdkman.io"
+                record.operation shouldBe AuditOperation.TAG
+
+                // and: version_data carries the tag plus (candidate, version, distribution, platform)
+                val auditData = Json.parseToJsonElement(record.versionData).jsonObject
+                auditData.getValue("candidate").jsonPrimitive.content shouldBe candidate
+                auditData.getValue("version").jsonPrimitive.content shouldBe version
+                auditData.getValue("tag").jsonPrimitive.content shouldBe "latest"
+                auditData.getValue("distribution").jsonPrimitive.content shouldBe distribution.name
+                auditData.getValue("platform").jsonPrimitive.content shouldBe platform.name
             }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -4,6 +4,8 @@ import arrow.core.some
 import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.ShouldSpec
 import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.shouldBe
 import io.ktor.client.request.*
 import io.ktor.client.request.bearerAuth
@@ -62,6 +64,66 @@ class PostVersionTagAssignmentAcceptanceSpec :
 
                 // and: the version carries the assigned tag
                 selectTagNames(versionId) shouldContain "latest"
+            }
+        }
+
+        should("move a tag from another version, leaving the source version's other tags intact") {
+            val candidate = "java"
+            val distribution = Distribution.TEMURIN
+            val platform = Platform.LINUX_X64
+
+            withCleanDatabase {
+                // given: version A holds "latest" and "27"; version B exists untagged
+                val versionIdA =
+                    insertVersionWithId(
+                        Version(
+                            candidate = candidate,
+                            version = "27.0.1",
+                            platform = platform,
+                            url = "https://java-27.0.1-tem",
+                            visible = true.some(),
+                            distribution = distribution.some(),
+                        ),
+                    )
+                val versionIdB =
+                    insertVersionWithId(
+                        Version(
+                            candidate = candidate,
+                            version = "27.0.2",
+                            platform = platform,
+                            url = "https://java-27.0.2-tem",
+                            visible = true.some(),
+                            distribution = distribution.some(),
+                        ),
+                    )
+                insertTag(candidate, "latest", distribution.some(), platform, versionIdA)
+                insertTag(candidate, "27", distribution.some(), platform, versionIdA)
+
+                // when: assigning "latest" to version B
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = candidate,
+                                    version = "27.0.2",
+                                    distribution = distribution.some(),
+                                    platform = platform,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 204 No Content
+                    response.status shouldBe HttpStatusCode.NoContent
+                }
+
+                // and: B gains "latest"; A loses "latest" but keeps "27"
+                selectTagNames(versionIdB) shouldContain "latest"
+                selectTagNames(versionIdA) shouldNotContain "latest"
+                selectTagNames(versionIdA) shouldContainExactlyInAnyOrder listOf("27")
             }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -350,4 +350,34 @@ class PostVersionTagAssignmentAcceptanceSpec :
                 }
             }
         }
+
+        should("return 400 Bad Request accumulating blank candidate, blank version, and invalid tag failures") {
+            withCleanDatabase {
+                // when: posting an assignment that violates three rules at once
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = "",
+                                    version = "",
+                                    distribution = Distribution.TEMURIN.some(),
+                                    platform = Platform.LINUX_X64,
+                                    tag = "-bad-",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 400 with all three failures reported together in one response
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    val body = response.bodyAsText()
+                    body shouldContain "Validation Error"
+                    body shouldContain "candidate cannot be empty"
+                    body shouldContain "version cannot be empty"
+                    body shouldContain "must start and end with an alphanumeric character"
+                }
+            }
+        }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -1,0 +1,67 @@
+package io.sdkman.state.acceptance
+
+import arrow.core.some
+import io.kotest.core.annotation.Tags
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.ktor.client.request.*
+import io.ktor.client.request.bearerAuth
+import io.ktor.http.*
+import io.sdkman.state.domain.model.Distribution
+import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.TagAssignment
+import io.sdkman.state.domain.model.Version
+import io.sdkman.state.support.*
+import io.sdkman.state.support.JwtTestSupport
+
+@Tags("acceptance")
+class PostVersionTagAssignmentAcceptanceSpec :
+    ShouldSpec({
+
+        should("assign a new tag to an existing version and return 204 No Content") {
+            val candidate = "java"
+            val version = "27.0.2"
+            val distribution = Distribution.TEMURIN
+            val platform = Platform.LINUX_X64
+
+            withCleanDatabase {
+                // given: a version with no tags
+                val versionId =
+                    insertVersionWithId(
+                        Version(
+                            candidate = candidate,
+                            version = version,
+                            platform = platform,
+                            url = "https://java-27.0.2-tem",
+                            visible = true.some(),
+                            distribution = distribution.some(),
+                        ),
+                    )
+
+                // when: assigning a tag to the version
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = candidate,
+                                    version = version,
+                                    distribution = distribution.some(),
+                                    platform = platform,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 204 No Content
+                    response.status shouldBe HttpStatusCode.NoContent
+                }
+
+                // and: the version carries the assigned tag
+                selectTagNames(versionId) shouldContain "latest"
+            }
+        }
+    })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -410,4 +410,34 @@ class PostVersionTagAssignmentAcceptanceSpec :
                 }
             }
         }
+
+        should("return 400 Bad Request when the distribution is not a valid enum value") {
+            // a raw body is needed: the typed DTO cannot represent an invalid Distribution
+            val requestBody =
+                """
+                {
+                    "candidate": "java",
+                    "version": "27.0.2",
+                    "distribution": "NOT_A_DISTRIBUTION",
+                    "platform": "LINUX_X64",
+                    "tag": "latest"
+                }
+                """.trimIndent()
+
+            withCleanDatabase {
+                // when: posting an assignment with an unknown distribution
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(requestBody)
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 400 — the bad enum is rejected at deserialization
+                    response.status shouldBe HttpStatusCode.BadRequest
+                    response.bodyAsText() shouldContain "Invalid request"
+                }
+            }
+        }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -464,4 +464,30 @@ class PostVersionTagAssignmentAcceptanceSpec :
                 }
             }
         }
+
+        should("return 403 Forbidden when a vendor assigns a tag for an unauthorized candidate") {
+            withCleanDatabase {
+                // when: a vendor scoped only to "scala" assigns a tag to a "java" version
+                withTestApplication {
+                    val vendorToken = JwtTestSupport.vendorToken(candidates = listOf("scala"))
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = "java",
+                                    version = "27.0.2",
+                                    distribution = Distribution.TEMURIN.some(),
+                                    platform = Platform.LINUX_X64,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(vendorToken)
+                        }
+
+                    // then: 403 — the candidate check rejects before any version lookup
+                    response.status shouldBe HttpStatusCode.Forbidden
+                }
+            }
+        }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -1,5 +1,6 @@
 package io.sdkman.state.acceptance
 
+import arrow.core.none
 import arrow.core.some
 import io.kotest.core.annotation.Tags
 import io.kotest.core.spec.style.ShouldSpec
@@ -218,6 +219,51 @@ class PostVersionTagAssignmentAcceptanceSpec :
 
                 // and: the tag set is unchanged
                 selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("latest")
+            }
+        }
+
+        should("assign a tag to a candidate without a distribution and return 204 No Content") {
+            val candidate = "gradle"
+            val version = "8.12"
+            val platform = Platform.UNIVERSAL
+
+            withCleanDatabase {
+                // given: a distribution-less version with no tags
+                val versionId =
+                    insertVersionWithId(
+                        Version(
+                            candidate = candidate,
+                            version = version,
+                            platform = platform,
+                            url = "https://gradle-8.12.zip",
+                            visible = true.some(),
+                            distribution = none(),
+                        ),
+                    )
+
+                // when: assigning a tag without a distribution
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = candidate,
+                                    version = version,
+                                    distribution = none(),
+                                    platform = platform,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 204 No Content
+                    response.status shouldBe HttpStatusCode.NoContent
+                }
+
+                // and: the version carries the assigned tag within the NULL-distribution scope
+                selectTagNames(versionId) shouldContain "latest"
             }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/PostVersionTagAssignmentAcceptanceSpec.kt
@@ -126,4 +126,51 @@ class PostVersionTagAssignmentAcceptanceSpec :
                 selectTagNames(versionIdA) shouldContainExactlyInAnyOrder listOf("27")
             }
         }
+
+        should("preserve the target version's existing tags when assigning a new one") {
+            val candidate = "java"
+            val version = "27.0.2"
+            val distribution = Distribution.TEMURIN
+            val platform = Platform.LINUX_X64
+
+            withCleanDatabase {
+                // given: a version already tagged "27"
+                val versionId =
+                    insertVersionWithId(
+                        Version(
+                            candidate = candidate,
+                            version = version,
+                            platform = platform,
+                            url = "https://java-27.0.2-tem",
+                            visible = true.some(),
+                            distribution = distribution.some(),
+                        ),
+                    )
+                insertTag(candidate, "27", distribution.some(), platform, versionId)
+
+                // when: assigning a new tag "latest" to the version
+                withTestApplication {
+                    val response =
+                        client.post("/versions/tags") {
+                            contentType(ContentType.Application.Json)
+                            setBody(
+                                TagAssignment(
+                                    candidate = candidate,
+                                    version = version,
+                                    distribution = distribution.some(),
+                                    platform = platform,
+                                    tag = "latest",
+                                ).toJsonString(),
+                            )
+                            bearerAuth(JwtTestSupport.adminToken())
+                        }
+
+                    // then: 204 No Content
+                    response.status shouldBe HttpStatusCode.NoContent
+                }
+
+                // and: the version carries both the existing and the newly assigned tag
+                selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("27", "latest")
+            }
+        }
     })

--- a/src/test/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepositoryIntegrationSpec.kt
@@ -234,6 +234,31 @@ class PostgresTagRepositoryIntegrationSpec :
                     selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("latest")
                 }
             }
+
+            should("preserve the version's existing tags when assigning a new tag") {
+                withCleanDatabase {
+                    // given: a version that already holds a tag
+                    val versionId =
+                        insertVersionWithId(
+                            Version(
+                                candidate = "java",
+                                version = "27.0.2",
+                                platform = Platform.LINUX_X64,
+                                url = "https://java-27.0.2",
+                                visible = true.some(),
+                                distribution = Distribution.TEMURIN.some(),
+                            ),
+                        )
+                    repo.assignTag(versionId, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "27").shouldBeRight()
+
+                    // when: a different tag is assigned to the same version
+                    val result = repo.assignTag(versionId, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest")
+
+                    // then: both the existing and the new tag are present (append, not replace)
+                    result.shouldBeRight()
+                    selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("27", "latest")
+                }
+            }
         }
 
         context("findTagsByVersionId") {

--- a/src/test/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepositoryIntegrationSpec.kt
@@ -141,6 +141,39 @@ class PostgresTagRepositoryIntegrationSpec :
             }
         }
 
+        context("assignTag") {
+            should("assign a previously-unassigned tag to a version") {
+                withCleanDatabase {
+                    // given: a version with no tags
+                    val versionId =
+                        insertVersionWithId(
+                            Version(
+                                candidate = "java",
+                                version = "27.0.2",
+                                platform = Platform.LINUX_X64,
+                                url = "https://java-27.0.2",
+                                visible = true.some(),
+                                distribution = Distribution.TEMURIN.some(),
+                            ),
+                        )
+
+                    // when: a tag is assigned
+                    val result =
+                        repo.assignTag(
+                            versionId = versionId,
+                            candidate = "java",
+                            distribution = Distribution.TEMURIN.some(),
+                            platform = Platform.LINUX_X64,
+                            tag = "latest",
+                        )
+
+                    // then: the tag row exists pointing at the target version
+                    result.shouldBeRight()
+                    selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("latest")
+                }
+            }
+        }
+
         context("findTagsByVersionId") {
             should("return all tags for a version") {
                 withCleanDatabase {

--- a/src/test/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepositoryIntegrationSpec.kt
@@ -172,6 +172,43 @@ class PostgresTagRepositoryIntegrationSpec :
                     selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("latest")
                 }
             }
+
+            should("move a tag to a different version, removing it from the original") {
+                withCleanDatabase {
+                    // given: two versions, the first holding the tag (mutual exclusivity scope)
+                    val versionId1 =
+                        insertVersionWithId(
+                            Version(
+                                candidate = "java",
+                                version = "27.0.1",
+                                platform = Platform.LINUX_X64,
+                                url = "https://java-27.0.1",
+                                visible = true.some(),
+                                distribution = Distribution.TEMURIN.some(),
+                            ),
+                        )
+                    val versionId2 =
+                        insertVersionWithId(
+                            Version(
+                                candidate = "java",
+                                version = "27.0.2",
+                                platform = Platform.LINUX_X64,
+                                url = "https://java-27.0.2",
+                                visible = true.some(),
+                                distribution = Distribution.TEMURIN.some(),
+                            ),
+                        )
+                    repo.assignTag(versionId1, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest").shouldBeRight()
+
+                    // when: the same tag is assigned to a different version in the same scope
+                    val result = repo.assignTag(versionId2, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest")
+
+                    // then: the tag re-points to the new version and the original no longer holds it
+                    result.shouldBeRight()
+                    selectTagNames(versionId1).shouldBeEmpty()
+                    selectTagNames(versionId2) shouldContainExactlyInAnyOrder listOf("latest")
+                }
+            }
         }
 
         context("findTagsByVersionId") {

--- a/src/test/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepositoryIntegrationSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/adapter/secondary/persistence/PostgresTagRepositoryIntegrationSpec.kt
@@ -209,6 +209,31 @@ class PostgresTagRepositoryIntegrationSpec :
                     selectTagNames(versionId2) shouldContainExactlyInAnyOrder listOf("latest")
                 }
             }
+
+            should("be an idempotent no-op when re-assigning a tag the version already holds") {
+                withCleanDatabase {
+                    // given: a version that already holds the tag
+                    val versionId =
+                        insertVersionWithId(
+                            Version(
+                                candidate = "java",
+                                version = "27.0.2",
+                                platform = Platform.LINUX_X64,
+                                url = "https://java-27.0.2",
+                                visible = true.some(),
+                                distribution = Distribution.TEMURIN.some(),
+                            ),
+                        )
+                    repo.assignTag(versionId, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest").shouldBeRight()
+
+                    // when: the same tag is assigned again
+                    val result = repo.assignTag(versionId, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest")
+
+                    // then: the operation succeeds and nothing changes
+                    result.shouldBeRight()
+                    selectTagNames(versionId) shouldContainExactlyInAnyOrder listOf("latest")
+                }
+            }
         }
 
         context("findTagsByVersionId") {

--- a/src/test/kotlin/io/sdkman/state/application/service/TagServiceUnitSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/application/service/TagServiceUnitSpec.kt
@@ -311,5 +311,43 @@ class TagServiceUnitSpec :
                 coVerify(exactly = 0) { tagsRepo.assignTag(any(), any(), any(), any(), any()) }
                 coVerify(exactly = 0) { auditRepo.recordAudit(any(), any(), any(), any()) }
             }
+
+            should("still succeed when audit logging fails after the tag is assigned") {
+                // given: the version exists and the tag write succeeds but the audit write fails
+                val assignment =
+                    TagAssignment(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "latest",
+                    )
+                val uniqueVersion =
+                    UniqueVersion(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                    )
+                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(42.some())
+                coEvery {
+                    tagsRepo.assignTag(42, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest")
+                } returns Either.Right(Unit)
+                coEvery {
+                    auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.TAG, assignment)
+                } returns
+                    Either.Left(
+                        DatabaseFailure.QueryExecutionFailure(
+                            "audit failed",
+                            RuntimeException("disk full"),
+                        ),
+                    )
+
+                // when: assigning the tag with a failing audit write
+                val result = service.assignTag(assignment, NIL_UUID, "admin")
+
+                // then: still succeeds (audit failure is logged but does not roll back the assignment)
+                result.shouldBeRight()
+            }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/application/service/TagServiceUnitSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/application/service/TagServiceUnitSpec.kt
@@ -278,5 +278,38 @@ class TagServiceUnitSpec :
                 }
                 coVerify { auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.TAG, assignment) }
             }
+
+            should("return VersionNotFound when the target version does not exist") {
+                // given: the target version cannot be resolved (no semverish validation gates the lookup)
+                val assignment =
+                    TagAssignment(
+                        candidate = "java",
+                        version = "99.0.0",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "latest",
+                    )
+                val uniqueVersion =
+                    UniqueVersion(
+                        candidate = "java",
+                        version = "99.0.0",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                    )
+                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(none())
+
+                // when: assigning the tag to the absent version
+                val result = service.assignTag(assignment, NIL_UUID, "admin")
+
+                // then: raises VersionNotFound without touching the tag write or audit
+                result.shouldBeLeft()
+                result.onLeft { error ->
+                    error.shouldBeInstanceOf<DomainError.VersionNotFound>()
+                    error.candidate shouldBe "java"
+                    error.version shouldBe "99.0.0"
+                }
+                coVerify(exactly = 0) { tagsRepo.assignTag(any(), any(), any(), any(), any()) }
+                coVerify(exactly = 0) { auditRepo.recordAudit(any(), any(), any(), any()) }
+            }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/application/service/TagServiceUnitSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/application/service/TagServiceUnitSpec.kt
@@ -349,5 +349,81 @@ class TagServiceUnitSpec :
                 // then: still succeeds (audit failure is logged but does not roll back the assignment)
                 result.shouldBeRight()
             }
+
+            should("return DatabaseError when the tag write fails") {
+                // given: the version exists but the tag write fails (the 500 path)
+                val assignment =
+                    TagAssignment(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "latest",
+                    )
+                val uniqueVersion =
+                    UniqueVersion(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                    )
+                val dbFailure =
+                    DatabaseFailure.QueryExecutionFailure(
+                        "connection reset",
+                        RuntimeException("timeout"),
+                    )
+                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(42.some())
+                coEvery {
+                    tagsRepo.assignTag(42, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest")
+                } returns Either.Left(dbFailure)
+
+                // when: assigning the tag while the repository fails
+                val result = service.assignTag(assignment, NIL_UUID, "admin")
+
+                // then: surfaces DatabaseError and never records an audit
+                result.shouldBeLeft()
+                result.onLeft { error ->
+                    error.shouldBeInstanceOf<DomainError.DatabaseError>()
+                    error.failure shouldBe dbFailure
+                }
+                coVerify(exactly = 0) { auditRepo.recordAudit(any(), any(), any(), any()) }
+            }
+
+            should("return DatabaseError when the version lookup fails") {
+                // given: the version lookup itself fails before any tag write
+                val assignment =
+                    TagAssignment(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "latest",
+                    )
+                val uniqueVersion =
+                    UniqueVersion(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                    )
+                val dbFailure =
+                    DatabaseFailure.QueryExecutionFailure(
+                        "connection lost",
+                        RuntimeException("timeout"),
+                    )
+                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Left(dbFailure)
+
+                // when: assigning the tag while the version lookup fails
+                val result = service.assignTag(assignment, NIL_UUID, "admin")
+
+                // then: surfaces DatabaseError without touching the tag write or audit
+                result.shouldBeLeft()
+                result.onLeft { error ->
+                    error.shouldBeInstanceOf<DomainError.DatabaseError>()
+                    error.failure shouldBe dbFailure
+                }
+                coVerify(exactly = 0) { tagsRepo.assignTag(any(), any(), any(), any(), any()) }
+                coVerify(exactly = 0) { auditRepo.recordAudit(any(), any(), any(), any()) }
+            }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/application/service/TagServiceUnitSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/application/service/TagServiceUnitSpec.kt
@@ -15,9 +15,12 @@ import io.sdkman.state.domain.error.DomainError
 import io.sdkman.state.domain.model.AuditOperation
 import io.sdkman.state.domain.model.Distribution
 import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.TagAssignment
 import io.sdkman.state.domain.model.UniqueTag
+import io.sdkman.state.domain.model.UniqueVersion
 import io.sdkman.state.domain.repository.AuditRepository
 import io.sdkman.state.domain.repository.TagRepository
+import io.sdkman.state.domain.repository.VersionRepository
 import io.sdkman.state.support.shouldBeLeft
 import io.sdkman.state.support.shouldBeRight
 import java.util.UUID
@@ -29,7 +32,8 @@ class TagServiceUnitSpec :
     ShouldSpec({
         val tagsRepo = mockk<TagRepository>()
         val auditRepo = mockk<AuditRepository>()
-        val service = TagServiceImpl(tagsRepo, auditRepo)
+        val versionsRepo = mockk<VersionRepository>()
+        val service = TagServiceImpl(tagsRepo, auditRepo, versionsRepo)
 
         beforeEach { clearAllMocks() }
 
@@ -234,6 +238,45 @@ class TagServiceUnitSpec :
                 coVerify {
                     auditRepo.recordAudit(VENDOR_UUID, "vendor@example.com", AuditOperation.DELETE, uniqueTag)
                 }
+            }
+        }
+
+        context("assignTag") {
+
+            should("assign the tag, delegating to the repository and recording a TAG audit") {
+                // given: the target version exists and the tag write + audit both succeed
+                val assignment =
+                    TagAssignment(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "latest",
+                    )
+                val uniqueVersion =
+                    UniqueVersion(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                    )
+                coEvery { versionsRepo.findVersionId(uniqueVersion) } returns Either.Right(42.some())
+                coEvery {
+                    tagsRepo.assignTag(42, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest")
+                } returns Either.Right(Unit)
+                coEvery {
+                    auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.TAG, assignment)
+                } returns Either.Right(Unit)
+
+                // when: assigning the tag
+                val result = service.assignTag(assignment, NIL_UUID, "admin")
+
+                // then: succeeds, delegates to the repository, and records a TAG audit
+                result.shouldBeRight()
+                coVerify {
+                    tagsRepo.assignTag(42, "java", Distribution.TEMURIN.some(), Platform.LINUX_X64, "latest")
+                }
+                coVerify { auditRepo.recordAudit(NIL_UUID, "admin", AuditOperation.TAG, assignment) }
             }
         }
     })

--- a/src/test/kotlin/io/sdkman/state/application/validation/TagAssignmentValidatorSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/application/validation/TagAssignmentValidatorSpec.kt
@@ -1,0 +1,135 @@
+package io.sdkman.state.application.validation
+
+import arrow.core.some
+import io.kotest.core.spec.style.ShouldSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.sdkman.state.domain.model.Distribution
+import io.sdkman.state.domain.model.Platform
+import io.sdkman.state.domain.model.TagAssignment
+import io.sdkman.state.support.shouldBeLeft
+import io.sdkman.state.support.shouldBeRight
+
+class TagAssignmentValidatorSpec :
+    ShouldSpec({
+
+        context("validate") {
+            should("accept a valid assignment with distribution") {
+                // given: a fully specified tag assignment
+                val assignment =
+                    TagAssignment(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "latest",
+                    )
+
+                // when: validating
+                val result = TagAssignmentValidator.validate(assignment)
+
+                // then: returns Right with the same assignment
+                result shouldBeRight assignment
+            }
+
+            should("accept a valid assignment without distribution") {
+                // given: an assignment for a non-distribution candidate
+                val assignment =
+                    TagAssignment(
+                        candidate = "gradle",
+                        version = "8.12",
+                        distribution = arrow.core.none(),
+                        platform = Platform.UNIVERSAL,
+                        tag = "latest",
+                    )
+
+                // when: validating
+                val result = TagAssignmentValidator.validate(assignment)
+
+                // then: returns Right
+                result shouldBeRight assignment
+            }
+
+            should("reject when candidate is blank") {
+                // given: an assignment with blank candidate
+                val assignment =
+                    TagAssignment(
+                        candidate = "",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "latest",
+                    )
+
+                // when: validating
+                val result = TagAssignmentValidator.validate(assignment)
+
+                // then: returns Left with the candidate error
+                val errors = result.shouldBeLeft()
+                errors.size shouldBe 1
+                errors.first() shouldBe EmptyFieldError("candidate")
+            }
+
+            should("reject when version is blank") {
+                // given: an assignment with blank version
+                val assignment =
+                    TagAssignment(
+                        candidate = "java",
+                        version = "",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "latest",
+                    )
+
+                // when: validating
+                val result = TagAssignmentValidator.validate(assignment)
+
+                // then: returns Left with the version error
+                val errors = result.shouldBeLeft()
+                errors.size shouldBe 1
+                errors.first() shouldBe EmptyFieldError("version")
+            }
+
+            should("reject when tag format is invalid") {
+                // given: an assignment with a tag that breaks the tag-name rule
+                val assignment =
+                    TagAssignment(
+                        candidate = "java",
+                        version = "27.0.2",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "-bad-",
+                    )
+
+                // when: validating
+                val result = TagAssignmentValidator.validate(assignment)
+
+                // then: returns Left with an invalid-tag error on the `tag` field
+                val errors = result.shouldBeLeft()
+                errors.size shouldBe 1
+                errors.first().shouldBeInstanceOf<InvalidTagError>().field shouldBe "tag"
+            }
+
+            should("accumulate errors for blank candidate, blank version and invalid tag") {
+                // given: an assignment failing every structural rule at once
+                val assignment =
+                    TagAssignment(
+                        candidate = "",
+                        version = "",
+                        distribution = Distribution.TEMURIN.some(),
+                        platform = Platform.LINUX_X64,
+                        tag = "-bad-",
+                    )
+
+                // when: validating
+                val result = TagAssignmentValidator.validate(assignment)
+
+                // then: returns Left with all three errors accumulated
+                val errors = result.shouldBeLeft()
+                errors.size shouldBe 3
+                errors.toList()[0] shouldBe EmptyFieldError("candidate")
+                errors.toList()[1] shouldBe EmptyFieldError("version")
+                errors.toList()[2].shouldBeInstanceOf<InvalidTagError>().field shouldBe "tag"
+            }
+        }
+    })

--- a/src/test/kotlin/io/sdkman/state/support/Application.kt
+++ b/src/test/kotlin/io/sdkman/state/support/Application.kt
@@ -76,7 +76,7 @@ fun withTestApplication(fn: suspend (ApplicationTestBuilder.() -> Unit)) {
             val tagsRepo = PostgresTagRepository()
             val auditRepo = PostgresAuditRepository()
             val vendorRepo = PostgresVendorRepository()
-            val tagService = TagServiceImpl(tagsRepo, auditRepo)
+            val tagService = TagServiceImpl(tagsRepo, auditRepo, versionsRepo)
             val transactional = ExposedTransactional()
             val rateLimiter = RateLimiter()
             val authService = AuthServiceImpl(vendorRepo, sharedTestAppConfig, rateLimiter)

--- a/src/test/kotlin/io/sdkman/state/support/Json.kt
+++ b/src/test/kotlin/io/sdkman/state/support/Json.kt
@@ -2,10 +2,12 @@ package io.sdkman.state.support
 
 import arrow.core.getOrElse
 import arrow.core.toOption
+import io.sdkman.state.adapter.primary.rest.dto.TagAssignmentDto
 import io.sdkman.state.adapter.primary.rest.dto.UniqueTagDto
 import io.sdkman.state.adapter.primary.rest.dto.UniqueVersionDto
 import io.sdkman.state.adapter.primary.rest.dto.VersionDto
 import io.sdkman.state.adapter.primary.rest.dto.toDto
+import io.sdkman.state.domain.model.TagAssignment
 import io.sdkman.state.domain.model.UniqueTag
 import io.sdkman.state.domain.model.UniqueVersion
 import io.sdkman.state.domain.model.Version
@@ -22,6 +24,8 @@ fun Version.toJsonString() = this.toJson().toString()
 fun UniqueVersion.toJsonString() = Json.encodeToJsonElement(UniqueVersionDto(candidate, version, distribution, platform)).toString()
 
 fun UniqueTag.toJsonString() = Json.encodeToJsonElement(UniqueTagDto(candidate, tag, distribution, platform)).toString()
+
+fun TagAssignment.toJsonString() = Json.encodeToJsonElement(TagAssignmentDto(candidate, version, platform, distribution, tag)).toString()
 
 fun String.parseJsonObject(): JsonObject = Json.decodeFromString<JsonObject>(this)
 


### PR DESCRIPTION
## What & why

Adds a dedicated, focused endpoint — `POST /versions/tags` — for assigning a **single** tag to an **existing** version, without re-posting the whole version payload.

Today the only way to change a version's tags is `POST /versions`, which applies *replace* semantics to the entire tag set. This endpoint is the write-side counterpart to the existing `GET /versions/{candidate}/tags/{tag}` (resolve) and `DELETE /versions/tags` (remove), completing the targeted tag lifecycle: **assign, resolve, remove** — none of which touch the version payload.

Behaviour ("assert that this version holds this tag"):

- Tag unassigned in scope → **added** to the target version.
- Tag on a different version in the same `(candidate, distribution, platform)` scope → **moved** to the target.
- Tag already on the target → **idempotent no-op**, still `204`.

In all cases the target's other tags are preserved (append, never replace). The endpoint never creates a version — a non-existent target yields `404`. No semverish validation is applied to `version` (creation-time gate only). Same auth model as `POST /versions`: JWT required, admin bypasses candidate checks, vendors must be authorized for the request's `candidate`.

## Changes

Built bottom-up so each `./gradlew check` stayed green at every layer:

- **Audit** — new `AuditOperation.TAG` value; new `TagAssignment` `Auditable` domain model + serialization into the existing `version_data` JSON column.
- **Persistence** — `assignTag` port on `TagRepository` + `PostgresTagRepository` impl: the single race-safe `UPSERT` already used inside `replaceTags`, **without** the delete-not-in-list step (covers move, idempotent no-op, and append in one statement). Integration tests for all four paths.
- **Service** — `TagService.assignTag` / `TagServiceImpl`: resolve the version id via `VersionRepository.findVersionId`, `404` on absent, delegate the write, then record a best-effort `TAG` audit (non-fatal on failure). Unit tests for happy path, `VersionNotFound`, audit-failure-non-fatal, and the `DatabaseError`/`500` path.
- **REST** — `TagAssignmentDto` request DTO, `TagAssignmentValidator` (with a shared `TagNameRules` extracted from `VersionRequestValidator`), and the `POST /versions/tags` route mirroring the `delete` handler.
- **Acceptance** — end-to-end coverage: assign/move/append/idempotent, no-distribution candidate, `404`, accumulated `400`s, `401`/`403`, and the `AuditOperation.TAG` record.
- **Docs** — OpenAPI `documentation.yaml` updated with the `POST /versions/tags` path and `TagAssignment` schema.

No database migration — `version_tags` already exists and the enriched audit detail rides the existing JSON column.

## Review

One review gap was found and then closed:

- **`assignTag` `DatabaseError`/`500` path was untested.** The spec requires "Returns `500` on database error" and both repository calls in `TagServiceImpl.assignTag` already map their `DatabaseFailure` via `.mapLeft { DomainError.DatabaseError(it) }.bind()`, but neither failure branch had a test (unlike `deleteTag`/`createOrUpdate`). Closed by two unit tests covering the `tagsRepo.assignTag` write failure and the `versionsRepo.findVersionId` lookup failure, both asserting `DomainError.DatabaseError` and that no audit is recorded.

With that closed, the spec is fully satisfied — every acceptance criterion is covered across the integration, unit, acceptance, and documentation layers.

## Test plan

```bash
./gradlew check   # compile → detekt → ktlintCheck → test (the full chain)
```

- Integration tests run against a Testcontainers Postgres (no external DB needed).
- Acceptance tests exercise the full HTTP route, including auth, validation, `404`, and audit.
- `TagServiceUnitSpec` covers the service branches (happy path, `VersionNotFound`, audit-failure-non-fatal, `DatabaseError`/`500`).

Note: `documentation.yaml` is not validated by `check`; the OpenAPI change was verified by inspection against the sibling `DELETE /versions/tags` entry.
