### PR TITLE
feat(distribution): add ELIYA distribution

### DIFF
--- a/src/main/kotlin/io/sdkman/state/domain/model/Distribution.kt
+++ b/src/main/kotlin/io/sdkman/state/domain/model/Distribution.kt
@@ -3,6 +3,7 @@ package io.sdkman.state.domain.model
 enum class Distribution {
     BISHENG,
     CORRETTO,
+    ELIYA,
     GRAALCE,
     GRAALVM,
     JETBRAINS,

--- a/src/main/resources/openapi/documentation.yaml
+++ b/src/main/resources/openapi/documentation.yaml
@@ -439,6 +439,7 @@ paths:
             enum:
               - "BISHENG"
               - "CORRETTO"
+              - "ELIYA"
               - "GRAALCE"
               - "GRAALVM"
               - "JETBRAINS"
@@ -520,6 +521,7 @@ paths:
             enum:
               - "BISHENG"
               - "CORRETTO"
+              - "ELIYA"
               - "GRAALCE"
               - "GRAALVM"
               - "JETBRAINS"
@@ -592,6 +594,7 @@ paths:
             enum:
               - "BISHENG"
               - "CORRETTO"
+              - "ELIYA"
               - "GRAALCE"
               - "GRAALVM"
               - "JETBRAINS"
@@ -658,6 +661,7 @@ components:
           enum:
             - "BISHENG"
             - "CORRETTO"
+            - "ELIYA"
             - "GRAALCE"
             - "GRAALVM"
             - "JETBRAINS"
@@ -700,6 +704,7 @@ components:
           enum:
             - "BISHENG"
             - "CORRETTO"
+            - "ELIYA"
             - "GRAALCE"
             - "GRAALVM"
             - "JETBRAINS"
@@ -742,6 +747,7 @@ components:
           enum:
             - "BISHENG"
             - "CORRETTO"
+            - "ELIYA"
             - "GRAALCE"
             - "GRAALVM"
             - "JETBRAINS"
@@ -936,6 +942,7 @@ components:
           enum:
             - "BISHENG"
             - "CORRETTO"
+            - "ELIYA"
             - "GRAALCE"
             - "GRAALVM"
             - "JETBRAINS"

--- a/src/test/kotlin/io/sdkman/state/acceptance/GetVersionAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/GetVersionAcceptanceSpec.kt
@@ -163,7 +163,7 @@ class GetVersionAcceptanceSpec :
                             ErrorResponse(
                                 "Bad Request",
                                 "Invalid distribution 'open'. Expected one of: " +
-                                    "BISHENG, CORRETTO, GRAALCE, GRAALVM, JETBRAINS, KONA, LIBERICA, " +
+                                    "BISHENG, CORRETTO, ELIYA, GRAALCE, GRAALVM, JETBRAINS, KONA, LIBERICA, " +
                                     "LIBERICA_NIK, MANDREL, MICROSOFT, OPENJDK, ORACLE, SAP_MACHINE, " +
                                     "SEMERU, TEMURIN, ZULU.",
                             )

--- a/src/test/kotlin/io/sdkman/state/acceptance/GetVersionsAcceptanceSpec.kt
+++ b/src/test/kotlin/io/sdkman/state/acceptance/GetVersionsAcceptanceSpec.kt
@@ -276,7 +276,7 @@ class GetVersionsAcceptanceSpec :
                             ErrorResponse(
                                 "Bad Request",
                                 "Invalid distribution 'open'. Expected one of: " +
-                                    "BISHENG, CORRETTO, GRAALCE, GRAALVM, JETBRAINS, KONA, LIBERICA, " +
+                                    "BISHENG, CORRETTO, ELIYA, GRAALCE, GRAALVM, JETBRAINS, KONA, LIBERICA, " +
                                     "LIBERICA_NIK, MANDREL, MICROSOFT, OPENJDK, ORACLE, SAP_MACHINE, " +
                                     "SEMERU, TEMURIN, ZULU.",
                             )


### PR DESCRIPTION
## Summary

Adds `ELIYA` as a new value to the `Distribution` enum.

## Changes

- **`Distribution.kt`** — add `ELIYA` to the enum (alphabetical, between `CORRETTO` and `GRAALCE`).
- **`documentation.yaml`** — add `ELIYA` to all 7 distribution `enum` blocks in the OpenAPI spec, keeping the contract in sync.
- **`GetVersionAcceptanceSpec.kt` / `GetVersionsAcceptanceSpec.kt`** — update the hardcoded "Expected one of: …" vocabulary strings, since the invalid-distribution error message is generated from `Distribution.entries`.

## Notes

No other changes were needed — parsing, validation, persistence, and DTOs all derive from `Distribution.entries`/`valueOf`, and the `distribution` DB column is free-text `VARCHAR` with no enumerated `CHECK` constraint, so there is no migration to write.

## Validation

- `./gradlew ktlintCheck` — clean
- Both affected acceptance specs pass (`GetVersionAcceptanceSpec`, `GetVersionsAcceptanceSpec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)